### PR TITLE
Add support to configure the API client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Ribose
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/ribose`. To experiment with that code, run `bin/console` for an interactive prompt.
+[![Build
+Status](https://travis-ci.org/riboseinc/ribose-ruby.svg?branch=master)](https://travis-ci.org/riboseinc/ribose-ruby)
+[![Code
+Climate](https://codeclimate.com/github/riboseinc/ribose-ruby/badges/gpa.svg)](https://codeclimate.com/github/riboseinc/ribose-ruby)
 
-TODO: Delete this and the text above, and describe your gem
+The Ruby Interface to the Ribose API.
 
 ## Installation
 
@@ -22,6 +25,33 @@ Or install it yourself as:
 
 ```sh
 $ gem install ribose
+```
+
+## Configure
+
+We need to setup Ribose API configuration before we can perform any request
+throughout this client, and to request an API Key please contact Ribose Inc.
+Once you have your API key then you can configure it by adding an initializer
+with the following code
+
+```ruby
+Ribose.configure do |config|
+  config.api_key = "SECRET_API_KEY"
+
+  # There are also some default configurations, normally you do not need to
+  # change those unless you have some very specific use case scenario. The
+  # default response type is `object`, but it also supports other formats
+  #
+  # config.debug_mode = false
+  # config.response_type = :object
+  # config.api_host = "https://www.ribose.com"
+end
+```
+
+Or
+
+```ruby
+Ribose.configuration.api_key = "SECRET_API_KEY"
 ```
 
 ## Usage

--- a/lib/ribose.rb
+++ b/lib/ribose.rb
@@ -1,4 +1,5 @@
 require "ribose/version"
+require "ribose/config"
 
 module Ribose
   # Your code goes here...

--- a/lib/ribose/config.rb
+++ b/lib/ribose/config.rb
@@ -1,0 +1,21 @@
+require "ribose/configuration"
+
+module Ribose
+  module Config
+    def configure
+      if block_given?
+        yield configuration
+      end
+    end
+
+    def configuration
+      @configuration ||= Configuration.new
+    end
+  end
+
+  # This following line exposes `Ribose::Config` moduel's methods in class
+  # scope, so we can easily use those to configure or access Ribose config
+  # throughout the gem and the client applications.
+  #
+  extend Config
+end

--- a/lib/ribose/configuration.rb
+++ b/lib/ribose/configuration.rb
@@ -1,0 +1,12 @@
+module Ribose
+  class Configuration
+    attr_accessor :api_host, :api_key, :response_type, :debug_mode
+
+    def initialize
+      @api_host = "https://www.ribose.com"
+
+      @debug_mode = false
+      @response_type = :object
+    end
+  end
+end

--- a/spec/ribose/config_spec.rb
+++ b/spec/ribose/config_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+
+RSpec.describe Ribose::Config do
+  after { restore_to_default_config }
+
+  describe ".configure" do
+    it "allows us to set our configuration" do
+      api_host = "https://www.example.com"
+      api_key = "SUPER_SECRET_API_KEY"
+
+      Ribose.configure do |config|
+        config.api_key = api_key
+        config.api_host = api_host
+        config.debug_mode = false
+        config.response_type = :object
+      end
+
+      expect(Ribose.configuration.api_key).to eq(api_key)
+      expect(Ribose.configuration.api_host).to eq(api_host)
+    end
+  end
+
+  describe ".configuration" do
+    it "returns the default configuration" do
+      configuration = Ribose.configuration
+
+      expect(configuration.api_key).to be_nil
+      expect(configuration.debug_mode).to be_falsey
+      expect(configuration.response_type).to eq(:object)
+      expect(configuration.api_host).to eq("https://www.ribose.com")
+    end
+  end
+
+  def restore_to_default_config
+    Ribose.configuration.api_key = nil
+    Ribose.configuration.api_host = "https://www.ribose.com"
+  end
+end


### PR DESCRIPTION
This commit adds support to configure `API_KEY`, `API_HOST`, and also to set the `respose_type` with `debug_mode` turn on or off. By default we only need to set the `API_KEY` and everything other configuration has a predefined defaults with override capability.

To setup our Ribose API configuration we can use the following code, but please check the Readme for all available config options

```ruby
Ribose.configure do |ribose_config|
  ribose_config.api_key = "YOUR_SECRET_API_KEY"
end
```