### PR TITLE
Add Ribose specific custom configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,22 +36,21 @@ with the following code
 
 ```ruby
 Ribose.configure do |config|
-  config.api_key = "SECRET_API_KEY"
+  config.api_token = "SECRET_API_TOKEN"
+  config.user_email = "your-email@example.com"
 
   # There are also some default configurations, normally you do not need to
-  # change those unless you have some very specific use case scenario. The
-  # default response type is `object`, but it also supports other formats
+  # change those unless you have some very specific use case scenario.
   #
-  # config.debug_mode = false
-  # config.response_type = :object
-  # config.api_host = "https://www.ribose.com"
+  # config.api_host = "www.ribose.com"
 end
 ```
 
 Or
 
 ```ruby
-Ribose.configuration.api_key = "SECRET_API_KEY"
+Ribose.configuration.api_token = "SECRET_API_TOKEN"
+Ribose.contribution.user_email = "your-email@example.com"
 ```
 
 ## Usage

--- a/lib/ribose/configuration.rb
+++ b/lib/ribose/configuration.rb
@@ -1,12 +1,9 @@
 module Ribose
   class Configuration
-    attr_accessor :api_host, :api_key, :response_type, :debug_mode
+    attr_accessor :api_host, :api_token, :user_email
 
     def initialize
-      @api_host = "https://www.ribose.com"
-
-      @debug_mode = false
-      @response_type = :object
+      @api_host ||= "www.ribose.com"
     end
   end
 end

--- a/spec/ribose/config_spec.rb
+++ b/spec/ribose/config_spec.rb
@@ -5,18 +5,19 @@ RSpec.describe Ribose::Config do
 
   describe ".configure" do
     it "allows us to set our configuration" do
-      api_host = "https://www.example.com"
-      api_key = "SUPER_SECRET_API_KEY"
+      api_host = "www.example.com"
+      api_token = "SUPER_SECRET_API_TOKEN"
+      user_email = "john.doe@example.com"
 
       Ribose.configure do |config|
-        config.api_key = api_key
         config.api_host = api_host
-        config.debug_mode = false
-        config.response_type = :object
+        config.api_token = api_token
+        config.user_email = user_email
       end
 
-      expect(Ribose.configuration.api_key).to eq(api_key)
       expect(Ribose.configuration.api_host).to eq(api_host)
+      expect(Ribose.configuration.api_token).to eq(api_token)
+      expect(Ribose.configuration.user_email).to eq(user_email)
     end
   end
 
@@ -24,15 +25,14 @@ RSpec.describe Ribose::Config do
     it "returns the default configuration" do
       configuration = Ribose.configuration
 
-      expect(configuration.api_key).to be_nil
-      expect(configuration.debug_mode).to be_falsey
-      expect(configuration.response_type).to eq(:object)
-      expect(configuration.api_host).to eq("https://www.ribose.com")
+      expect(configuration.api_token).to be_nil
+      expect(configuration.api_host).to eq("www.ribose.com")
     end
   end
 
   def restore_to_default_config
-    Ribose.configuration.api_key = nil
-    Ribose.configuration.api_host = "https://www.ribose.com"
+    Ribose.configuration.api_token = nil
+    Ribose.configuration.user_email = nil
+    Ribose.configuration.api_host = "www.ribose.com"
   end
 end


### PR DESCRIPTION
Ribose API requires us to provides a custom token and user email to respond to any of our API request. This commit expose those attributes as configuration, so now we can easily set those attributes through an initializer or inline configuration. The required keys are `api_token` and the `user_email`.

```ruby
Ribose.configure do |ribose_config|
  ribose_config.api_token = "SECRET_API_TOKEN"
  ribose_config.user_email = "your-email@example.com"
end
```