### PR TITLE
Add simple client for API communication

### DIFF
--- a/lib/ribose.rb
+++ b/lib/ribose.rb
@@ -1,5 +1,6 @@
 require "ribose/version"
 require "ribose/config"
+require "ribose/request"
 
 module Ribose
   # Your code goes here...

--- a/lib/ribose/request.rb
+++ b/lib/ribose/request.rb
@@ -1,0 +1,67 @@
+require "uri"
+require "net/http"
+require "ribose/response"
+
+module Ribose
+  class Request
+    def initialize(http_method, endpoint, **attributes)
+      @http_method = http_method
+      @endpoint = endpoint
+      @attributes = attributes
+    end
+
+    def run
+      Ribose::Response.new(send_http_request)
+    end
+
+    def self.get(endpoint)
+      new(:get, endpoint).run
+    end
+
+    private
+
+    attr_reader :endpoint, :http_method, :attributes
+
+    def send_http_request
+      Net::HTTP.start(*net_http_options) do |http|
+        http.request(http_request)
+      end
+    end
+
+    def net_http_options
+      [uri.host, uri.port, use_ssl: true]
+    end
+
+    def uri
+      URI::HTTPS.build(
+        host: Ribose.configuration.api_host,
+        path: ["", endpoint].join("/").squeeze("/"),
+      )
+    end
+
+    def http_request
+      @http_request ||= constanize_http_class.new(uri).tap do |request|
+        set_request_body!(request)
+        set_request_headers!(request)
+      end
+    end
+
+    def constanize_http_class
+      Object.const_get("Net::HTTP::#{http_method.capitalize}")
+    end
+
+    def set_request_headers!(request)
+      request.initialize_http_header(
+        "Accept" => "application/json",
+        "X-Indigo-Token" => Ribose.configuration.api_token,
+        "X-Indigo-Email" => Ribose.configuration.user_email,
+      )
+    end
+
+    def set_request_body!(request)
+      unless attributes.empty?
+        request.body = attributes.to_json
+      end
+    end
+  end
+end

--- a/lib/ribose/response.rb
+++ b/lib/ribose/response.rb
@@ -1,0 +1,23 @@
+require "json"
+
+module Ribose
+  class Response
+    def initialize(response)
+      @response = response
+    end
+
+    def data
+      if valid_response? && response.body
+        JSON.parse(response.body)
+      end
+    end
+
+    private
+
+    attr_reader :response
+
+    def valid_response?
+      response.is_a?(Net::HTTPSuccess)
+    end
+  end
+end

--- a/ribose.gemspec
+++ b/ribose.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "webmock", "~> 2.0"
 end

--- a/spec/ribose/request_spec.rb
+++ b/spec/ribose/request_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+
+RSpec.describe Ribose::Request do
+  describe ".get" do
+    it "retrieve the resource via a http :get" do
+      endpoint = "ping"
+
+      stub_ribose_ping_api_request
+      response = Ribose::Request.get(endpoint)
+
+      expect(response.data["data"]).to eq("Pong!")
+    end
+  end
+
+  def stub_ribose_ping_api_request
+    stub_request(:get, "https://www.ribose.com/ping").
+      with(headers: { "Accept" => "application/json" }).
+      to_return(status: 200, body: "{ \"data\": \"Pong!\" }")
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require "webmock/rspec"
 require "bundler/setup"
 require "ribose"
 


### PR DESCRIPTION
This commit adds a  pretty simple API client to handle communication between the Ribose API server and the client, this is more likely a wrapper on top of the `Net::HTTP` standard library.

In the upcoming commits we will tweak this to support more http verb and also to handle API response and errors with full flexibility.