### PR TITLE
Retrieve the list of user's spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ return all of the user's settings.
 Ribose::Setting.all
 ```
 
+### Spaces
+
+#### List user's spaces
+
+To list user's spaces we can use the `Space.all` interface, and it will retrieve
+all of the spaces for the currently configured user.
+
+```ruby
+Ribose::Space.all
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/ribose.rb
+++ b/lib/ribose.rb
@@ -2,6 +2,7 @@ require "ribose/version"
 require "ribose/config"
 require "ribose/request"
 require "ribose/setting"
+require "ribose/space"
 
 module Ribose
   # Your code goes here...

--- a/lib/ribose/actions.rb
+++ b/lib/ribose/actions.rb
@@ -1,0 +1,6 @@
+require "ribose/actions/all"
+
+module Ribose
+  module Actions
+  end
+end

--- a/lib/ribose/actions/all.rb
+++ b/lib/ribose/actions/all.rb
@@ -1,0 +1,23 @@
+require "ribose/actions/base"
+
+module Ribose
+  module Actions
+    module All
+      extend Ribose::Actions::Base
+
+      def all
+        Ribose::Request.get(resource_path).data[resource_key.to_s]
+      end
+
+      def resource_key
+        resource_path
+      end
+
+      module ClassMethods
+        def all
+          new.all
+        end
+      end
+    end
+  end
+end

--- a/lib/ribose/actions/base.rb
+++ b/lib/ribose/actions/base.rb
@@ -1,0 +1,11 @@
+require "ribose/request"
+
+module Ribose
+  module Actions
+    module Base
+      def included(base)
+        base.extend(const_get(:ClassMethods))
+      end
+    end
+  end
+end

--- a/lib/ribose/space.rb
+++ b/lib/ribose/space.rb
@@ -1,13 +1,13 @@
 require "ribose/actions"
 
 module Ribose
-  class Setting
+  class Space
     include Ribose::Actions::All
 
     private
 
     def resource_path
-      "settings"
+      "spaces"
     end
   end
 end

--- a/spec/fixtures/spaces.json
+++ b/spec/fixtures/spaces.json
@@ -1,0 +1,61 @@
+{
+  "spaces":[
+    {
+      "id":"123456789",
+      "name":"Work",
+      "created_at": "2017-07-27T07:19:09.000+00:00",
+      "invite_access":"admins",
+      "space_category_id":null,
+      "visibility":"invisible",
+      "group_email":"work57",
+      "default_role_id":41592,
+      "join_requests_access":"disabled",
+      "active":true,
+      "description":"Client work related discussion",
+      "members_count":1,
+      "admin":true,
+      "invitable_roles":[
+        {
+          "id":41592,
+          "name":"Member",
+          "space_id":"123456789"
+        },
+        {
+          "id":41593,
+          "name":"Administrator",
+          "space_id":"123456789"
+        },
+        {
+          "id":41594,
+          "name":"Read only",
+          "space_id":"123456789"
+        }
+      ],
+      "owner":true,
+      "read_only":false,
+      "role_name":"Administrator",
+      "allow_invite":true,
+      "joined_at": "2017-07-27T07:19:09.000+00:00",
+      "access":"private",
+      "publishable?":false,
+      "user":{
+        "id":"63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+        "name":"Abu Nashir"
+      },
+      "owned_roles":[
+        {
+          "id":41592,
+          "name":"Member"
+        },
+        {
+          "id":41593,
+          "name":"Administrator"
+        },
+        {
+          "id":41594,
+          "name":"Read only"
+        }
+      ]
+    }
+  ]
+}

--- a/spec/ribose/space_spec.rb
+++ b/spec/ribose/space_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+RSpec.describe Ribose::Space do
+  describe ".all" do
+    it "retrieves the list of user spaces" do
+      stub_ribose_space_list_api
+      spaces = Ribose::Space.all
+
+      expect(spaces.first.id).to eq("123456789")
+      expect(spaces.first.name).to eq("Work")
+      expect(spaces.first.visibility).to eq("invisible")
+    end
+  end
+
+  def stub_ribose_space_list_api
+    stub_api_response(:get, "spaces", filename: "spaces", status: 200)
+  end
+end


### PR DESCRIPTION
This commit adds the interface to retrieve the list of currently configured user's spaces, this commit also extract the `all` action to a separate module so if some others resource needs this facility then all we need to do is include the module. Usage

```ruby
Ribose::Space.all
```