### PR TITLE
Retrieve the list of application data

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ Ribose.contribution.user_email = "your-email@example.com"
 
 ## Usage
 
+### App Data
+
+Ribose API provides an easier way to retrieve the list of App data, and to
+retrieve the list of app data we can use the `AppData.all` interface.
+
+```ruby
+Ribose::AppData.all
+```
+
 ### Settings
 
 #### List user's settings

--- a/lib/ribose.rb
+++ b/lib/ribose.rb
@@ -3,6 +3,7 @@ require "ribose/config"
 require "ribose/request"
 require "ribose/setting"
 require "ribose/space"
+require "ribose/app_data"
 
 module Ribose
   # Your code goes here...

--- a/lib/ribose/actions/all.rb
+++ b/lib/ribose/actions/all.rb
@@ -6,11 +6,18 @@ module Ribose
       extend Ribose::Actions::Base
 
       def all
-        Ribose::Request.get(resource_path).data[resource_key.to_s]
+        response = Ribose::Request.get(resource_path)
+        extract_root(response.data) || response.data
       end
 
       def resource_key
         resource_path
+      end
+
+      def extract_root(response)
+        unless resource_key.nil?
+          response[resource_key.to_s]
+        end
       end
 
       module ClassMethods

--- a/lib/ribose/app_data.rb
+++ b/lib/ribose/app_data.rb
@@ -1,0 +1,15 @@
+module Ribose
+  class AppData
+    include Ribose::Actions::All
+
+    private
+
+    def resource_key
+      nil
+    end
+
+    def resource_path
+      "app_data"
+    end
+  end
+end

--- a/spec/fixtures/app_data.json
+++ b/spec/fixtures/app_data.json
@@ -1,0 +1,188 @@
+{
+  "misc": {
+    "jabber": {
+      "login": "c6fe2f942a69abad4bd7bdc90e58263e",
+      "status": "available",
+      "status_message": null
+    },
+    "locale": "en",
+    "notification": {
+      "notifications_last_received": 1302172,
+      "notifications_last_shown": 1302172
+    },
+    "capps": [
+      {
+        "id": 107953,
+        "app_name": "app/dashboard",
+        "enabled": true,
+        "name": null,
+        "order_id": 0,
+        "used_storage": 0,
+        "owner_type": "Space",
+        "owner_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc",
+        "system": true,
+        "app_type": "home",
+        "space_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc",
+        "namespace": "dashboard",
+        "show_in_menu?": true,
+        "uses_email_notifications?": false,
+        "searchable?": true
+      },
+      {
+        "id": 107954,
+        "app_name": "app/discussion",
+        "enabled": true,
+        "name": null,
+        "order_id": 1,
+        "used_storage": 0,
+        "owner_type": "Space",
+        "owner_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc",
+        "system": false,
+        "app_type": "discussion",
+        "space_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc",
+        "namespace": "discussion",
+        "show_in_menu?": true,
+        "uses_email_notifications?": true,
+        "searchable?": true
+      },
+      {
+        "id": 107955,
+        "app_name": "app/file",
+        "enabled": true,
+        "name": null,
+        "order_id": 2,
+        "used_storage": 0,
+        "owner_type": "Space",
+        "owner_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc",
+        "system": false,
+        "app_type": "file",
+        "space_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc",
+        "namespace": "file",
+        "show_in_menu?": true,
+        "uses_email_notifications?": true,
+        "searchable?": true
+      },
+      {
+        "id": 107956,
+        "app_name": "app/member",
+        "enabled": true,
+        "name": null,
+        "order_id": 3,
+        "used_storage": 0,
+        "owner_type": "Space",
+        "owner_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc",
+        "system": true,
+        "app_type": "people",
+        "space_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc",
+        "namespace": "people",
+        "show_in_menu?": true,
+        "uses_email_notifications?": true,
+        "searchable?": false
+      },
+      {
+        "id": 107957,
+        "app_name": "app/calendar",
+        "enabled": true,
+        "name": null,
+        "order_id": 4,
+        "used_storage": 0,
+        "owner_type": "Space",
+        "owner_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc",
+        "system": true,
+        "app_type": "calendar",
+        "space_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc",
+        "namespace": "calendar",
+        "show_in_menu?": true,
+        "uses_email_notifications?": true,
+        "searchable?": true
+      },
+      {
+        "id": 107958,
+        "app_name": "app/wiki",
+        "enabled": true,
+        "name": null,
+        "order_id": 5,
+        "used_storage": 0,
+        "owner_type": "Space",
+        "owner_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc",
+        "system": false,
+        "app_type": "wiki",
+        "space_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc",
+        "namespace": "wiki",
+        "show_in_menu?": true,
+        "uses_email_notifications?": true,
+        "searchable?": true
+      },
+      {
+        "id": 107959,
+        "app_name": "app/poll",
+        "enabled": true,
+        "name": null,
+        "order_id": 6,
+        "used_storage": 0,
+        "owner_type": "Space",
+        "owner_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc",
+        "system": false,
+        "app_type": "poll",
+        "space_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc",
+        "namespace": "poll",
+        "show_in_menu?": true,
+        "uses_email_notifications?": true,
+        "searchable?": true
+      }
+    ],
+    "status_message": null,
+    "number_of_connection": 1
+  },
+  "user": {
+    "id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+    "login": "john.doe",
+    "email": "john.doe@gmail.com",
+    "created_at": "2017-07-27T07:18:16.000+00:00",
+    "activity_points": {
+      "level": 0,
+      "total": 0,
+      "last7days": 0,
+      "last30days": 0,
+      "points_till_next_level": 35,
+      "points_for_current_level": 34
+    },
+    "mutual_users": [
+      "e674a27a-4bfe-5cb3-96a1-09a891db8422"
+    ],
+    "visible_spaces": [
+      {
+        "id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc",
+        "name": "Work",
+        "visibility": "invisible",
+        "members_count": 1
+      }
+    ],
+    "connection_id": null,
+    "from_ribose?": false,
+    "name": "John Doe",
+    "connected_users": [
+      {
+        "id": "e674a27a-4bfe-5cb3-96a1-09a891db8422",
+        "name": "Team Ribose",
+        "mutual_spaces": []
+      }
+    ],
+    "badge_states": [
+      {
+        "badge_id": 2,
+        "state": "unlocked",
+        "rank": null,
+        "unlocked_at": "2017-07-27T07:18:17.000+00:00"
+      }
+    ],
+    "profile": {
+      "id": 9632,
+      "first_name": "John",
+      "last_name": "Doe",
+      "user_id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+      "fields": {},
+      "name": "John Doe"
+    }
+  }
+}

--- a/spec/ribose/app_data_spec.rb
+++ b/spec/ribose/app_data_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+RSpec.describe Ribose::AppData do
+  describe ".all" do
+    it "retrieves the user's app data" do
+      stub_ribose_app_data_api
+      app_data = Ribose::AppData.all
+
+      expect(app_data.user.login).to eq("john.doe")
+      expect(app_data.user.from_ribose?).to be_falsey
+      expect(app_data.misc.jabber.status).to eq("available")
+      expect(app_data.misc.capps.first.app_name).to eq("app/dashboard")
+    end
+  end
+
+  def stub_ribose_app_data_api
+    stub_api_response(:get, "app_data", filename: "app_data", status: 200)
+  end
+end


### PR DESCRIPTION
This commit adds the interface to retrieve the list of application data, and to retrieve the list we can use the following interface

```ruby
Ribose::AppData.all
```