### PR TITLE
Add interface to retrieve user feeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ all of the spaces for the currently configured user.
 Ribose::Space.all
 ```
 
+### Feeds
+
+### List user feeds
+
+To retrieve the list of user feeds, we can use the `Feed.all` interface
+
+```ruby
+Ribose::Feed.all
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/ribose.rb
+++ b/lib/ribose.rb
@@ -5,6 +5,7 @@ require "ribose/setting"
 require "ribose/space"
 require "ribose/app_data"
 require "ribose/app_relation"
+require "ribose/feed"
 
 module Ribose
   # Your code goes here...

--- a/lib/ribose/feed.rb
+++ b/lib/ribose/feed.rb
@@ -1,0 +1,11 @@
+module Ribose
+  class Feed
+    include Ribose::Actions::All
+
+    private
+
+    def resource_path
+      "feeds"
+    end
+  end
+end

--- a/spec/fixtures/feeds.json
+++ b/spec/fixtures/feeds.json
@@ -1,0 +1,84 @@
+{
+  "feeds": [
+    {
+      "id": 6320867,
+      "level": "user",
+      "type_name": "user",
+      "type": "Feed::Basic",
+      "owner_type": "User",
+      "type_id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+      "owner_id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+      "instance_name": "John Doe"
+    },
+    {
+      "id": 6320868,
+      "level": "user",
+      "type_name": "connected_users",
+      "type": "Feed::Basic",
+      "owner_type": "User",
+      "type_id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+      "owner_id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+      "instance_name": null
+    },
+    {
+      "id": 6320882,
+      "level": "app",
+      "type_name": "discussion",
+      "type": "Feed::Email",
+      "owner_type": "User",
+      "type_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc",
+      "owner_id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+      "instance_name": "Work"
+    },
+    {
+      "id": 6320883,
+      "level": "app",
+      "type_name": "file",
+      "type": "Feed::Email",
+      "owner_type": "User",
+      "type_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc",
+      "owner_id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+      "instance_name": "Work"
+    },
+    {
+      "id": 6320884,
+      "level": "app",
+      "type_name": "people",
+      "type": "Feed::Email",
+      "owner_type": "User",
+      "type_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc",
+      "owner_id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+      "instance_name": "Work"
+    },
+    {
+      "id": 6320885,
+      "level": "app",
+      "type_name": "calendar",
+      "type": "Feed::Email",
+      "owner_type": "User",
+      "type_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc",
+      "owner_id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+      "instance_name": "Work"
+    },
+    {
+      "id": 6320886,
+      "level": "app",
+      "type_name": "wiki",
+      "type": "Feed::Email",
+      "owner_type": "User",
+      "type_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc",
+      "owner_id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+      "instance_name": "Work"
+    },
+    {
+      "id": 6320887,
+      "level": "app",
+      "type_name": "poll",
+      "type": "Feed::Email",
+      "owner_type": "User",
+      "type_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc",
+      "owner_id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+      "instance_name": "Work"
+    }
+  ]
+}

--- a/spec/ribose/feed_spec.rb
+++ b/spec/ribose/feed_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+
+RSpec.describe Ribose::Feed do
+  describe ".all" do
+    it "retrieves the list of user feeds" do
+      stub_ribose_feed_api
+      feeds = Ribose::Feed.all
+
+      expect(feeds.first.id).not_to be_nil
+      expect(feeds.first.type).to eq("Feed::Basic")
+      expect(feeds.first.instance_name).to eq("John Doe")
+    end
+  end
+
+  private
+
+  def stub_ribose_feed_api
+    stub_api_response(:get, "feeds", filename: "feeds", status: 200)
+  end
+end


### PR DESCRIPTION
This commit adds the interface to retrieve the list of user feeds, to retrieve the list we can use the following interface:

```ruby
Ribose::Feed.all
```