### PR TITLE
Add interface to retrieve all widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,22 @@ Ribose::Space.all
 
 ### Feeds
 
-### List user feeds
+#### List user feeds
 
 To retrieve the list of user feeds, we can use the `Feed.all` interface
 
 ```ruby
 Ribose::Feed.all
+```
+
+### Widgets
+
+#### List widgets
+
+To retrieve the list of widgets we can use the `Widget.all` interface
+
+```ruby
+Ribose::Widget.all
 ```
 
 ## Development

--- a/lib/ribose.rb
+++ b/lib/ribose.rb
@@ -6,6 +6,7 @@ require "ribose/space"
 require "ribose/app_data"
 require "ribose/app_relation"
 require "ribose/feed"
+require "ribose/widget"
 
 module Ribose
   # Your code goes here...

--- a/lib/ribose/widget.rb
+++ b/lib/ribose/widget.rb
@@ -1,0 +1,11 @@
+module Ribose
+  class Widget
+    include Ribose::Actions::All
+
+    private
+
+    def resource_path
+      "widgets"
+    end
+  end
+end

--- a/spec/fixtures/widgets.json
+++ b/spec/fixtures/widgets.json
@@ -1,0 +1,50 @@
+{
+  "widgets": [
+    {
+      "id": 72148,
+      "owner_type": "User",
+      "type": "Widget::RssFeed",
+      "pane": 0,
+      "position": 0,
+      "owner_id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+      "status": "loaded",
+      "settings": null
+    },
+    {
+      "id": 72149,
+      "owner_type": "User",
+      "type": "Widget::Weather",
+      "pane": 0,
+      "position": 1,
+      "owner_id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+      "status": "loaded",
+      "settings": {
+        "widget_id": 72149,
+        "type": "Setting::Widget::Weather"
+      }
+    },
+    {
+      "id": 72146,
+      "owner_type": "User",
+      "type": "Widget::Calendar",
+      "pane": 2,
+      "position": 0,
+      "owner_id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+      "status": "loaded",
+      "settings": null
+    },
+    {
+      "id": 72147,
+      "owner_type": "User",
+      "type": "Widget::Notification",
+      "pane": 2,
+      "position": 1,
+      "owner_id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+      "status": "loaded",
+      "settings": {
+        "widget_id": 72147,
+        "type": "Setting::Widget::Notification"
+      }
+    }
+  ]
+}

--- a/spec/ribose/widget_spec.rb
+++ b/spec/ribose/widget_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+RSpec.describe Ribose::Widget do
+  describe ".all" do
+    it "retrieves the list of widgets" do
+      stub_ribose_widget_list_api
+      widgets = Ribose::Widget.all
+
+      expect(widgets.first.id).not_to be_nil
+      expect(widgets.first.status).to eq("loaded")
+      expect(widgets.first.type).to eq("Widget::RssFeed")
+    end
+  end
+
+  def stub_ribose_widget_list_api
+    stub_api_response(:get, "widgets", filename: "widgets", status: 200)
+  end
+end


### PR DESCRIPTION
Ribose API exposes a `/widgets` endpoint, which can be used to retrieve the list of widgets. This commit utilize that endpoint and expose it through a very simple ruby interface. Usage

```ruby
Ribose::Widget.all
```