### PR TITLE
Add interface to retrieve leader board

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,17 @@ To retrieve the list of notifications we can use the `Stream.all` interface
 Ribose::Stream.all
 ```
 
+### Leaderboard
+
+#### Retrieve the current leadership board
+
+To retrieve the current leadership board, we can use the `Leaderboard.all`
+interface and it will return the details.
+
+```ruby
+Ribose::Leaderboard.all
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/ribose.rb
+++ b/lib/ribose.rb
@@ -8,6 +8,7 @@ require "ribose/app_relation"
 require "ribose/feed"
 require "ribose/widget"
 require "ribose/stream"
+require "ribose/leaderboard"
 
 module Ribose
   # Your code goes here...

--- a/lib/ribose/leaderboard.rb
+++ b/lib/ribose/leaderboard.rb
@@ -1,11 +1,11 @@
 module Ribose
-  class AppData
+  class Leaderboard
     include Ribose::Actions::All
 
     private
 
     def resource_path
-      "app_data"
+      "activity_point/leaderboard"
     end
   end
 end

--- a/lib/ribose/stream.rb
+++ b/lib/ribose/stream.rb
@@ -4,10 +4,6 @@ module Ribose
 
     private
 
-    def resource_key
-      nil
-    end
-
     def resource_path
       "stream"
     end

--- a/spec/fixtures/leaderboard.json
+++ b/spec/fixtures/leaderboard.json
@@ -1,0 +1,21 @@
+{
+  "leaderboard": [
+    {
+      "id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+      "login": "john.doe",
+      "name": "John Doe",
+      "avatar_path": "data:image/png;base64,",
+      "activity_points": {
+        "level": 0,
+        "total": 0,
+        "last7days": 0,
+        "last30days": 0,
+        "points_till_next_level": 35,
+        "points_for_current_level": 34,
+        "rank": 1
+      }
+    }
+  ],
+  "self_rank": 1,
+  "overall_rank": 40
+}

--- a/spec/ribose/leaderboard_spec.rb
+++ b/spec/ribose/leaderboard_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+
+RSpec.describe Ribose::Leaderboard do
+  describe ".all" do
+    it "retrieves the current leader board" do
+      stub_ribose_leaderboard_api
+      activity = Ribose::Leaderboard.all
+
+      expect(activity.self_rank).to eq(1)
+      expect(activity.overall_rank).to eq(40)
+      expect(activity.leaderboard.first.name).to eq("John Doe")
+      expect(activity.leaderboard.first.login).to eq("john.doe")
+    end
+  end
+
+  def stub_ribose_leaderboard_api
+    stub_api_response(
+      :get, "activity_point/leaderboard", filename: "leaderboard", status: 200
+    )
+  end
+end


### PR DESCRIPTION
Ribose API offers `/activity_point/leaderboard` endpoint that can be used to retrieve the current leadership board. This commit use this endpoint and expose it through a very simple interface. To retrieve the current leadership board we can use

```ruby
Ribose::Leaderboard.all
```