### PR TITLE
Add interface to retrieve the connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,17 @@ interface and it will return the details.
 Ribose::Leaderboard.all
 ```
 
+### Connections
+
+### List of connections
+
+To retrieve the list of connections, we can use the `Connection.all` interface
+and it will return the connection as `Sawyer::Resource`.
+
+```ruby
+Ribose::Connection.all
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/ribose.rb
+++ b/lib/ribose.rb
@@ -9,6 +9,7 @@ require "ribose/feed"
 require "ribose/widget"
 require "ribose/stream"
 require "ribose/leaderboard"
+require "ribose/connection"
 
 module Ribose
   # Your code goes here...

--- a/lib/ribose/connection.rb
+++ b/lib/ribose/connection.rb
@@ -1,0 +1,17 @@
+module Ribose
+  class Connection
+    # List Connections
+    #
+    # Note: Currently, There are some chaching in place for this endpoint
+    # which requires us to pass the `s` query params otherwise we might
+    # have some unexpected behavior sometime. That's why we are adding
+    # the `s` incase that's not present with the query options.
+    #
+    # @param options [Hash] Query parameters as a Hash
+    # @return [Sawyer::Resource]
+    #
+    def self.all(options = {})
+      Request.get("people/connections", query: { s: "" }.merge(options))
+    end
+  end
+end

--- a/lib/ribose/request.rb
+++ b/lib/ribose/request.rb
@@ -17,7 +17,7 @@ module Ribose
 
     # Make a HTTP Request
     #
-    # @options [Hash] - Additonal options hash
+    # @param options [Hash] Additonal options hash
     # @return [Sawyer::Resource]
     #
     def request(options = {})

--- a/spec/fixtures/connections.json
+++ b/spec/fixtures/connections.json
@@ -1,0 +1,28 @@
+{
+  "requested_at": 5882845244,
+  "rejected_ids": [],
+  "total": 1,
+  "indices": {
+    "0": 10887
+  },
+  "objects": [
+    {
+      "id": 10887,
+      "user_id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+      "connection_id": "e674a27a-4bfe-5cb3-96a1-09a891db8422",
+      "data_for_jabber": {
+        "id": "e674a27a-4bfe-5cb3-96a1-09a891db8422",
+        "login": "riboseteam",
+        "jid": "riboseteam@messaging.ribose.internal",
+        "name": "Team Ribose",
+        "mutual_spaces": []
+      },
+      "connected_user": {
+        "id": "e674a27a-4bfe-5cb3-96a1-09a891db8422",
+        "name": "Team Ribose",
+        "connected": true,
+        "mutual_spaces": []
+      }
+    }
+  ]
+}

--- a/spec/ribose/connection_spec.rb
+++ b/spec/ribose/connection_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+
+RSpec.describe Ribose::Connection do
+  describe ".all" do
+    it "retrieves the list of connections" do
+      stub_ribose_connection_list_api
+
+      connections = Ribose::Connection.all
+      first_connection = connections.objects.first
+
+      expect(first_connection.id).not_to be_nil
+      expect(first_connection.connection_id).not_to be_nil
+      expect(first_connection.data_for_jabber.login).to eq("riboseteam")
+    end
+  end
+
+  def stub_ribose_connection_list_api
+    stub_api_response(:get, "people/connections?s=", filename: "connections")
+  end
+end


### PR DESCRIPTION
The Ribose API offers `/people/connections` endpoints, which can be use to retrieve the list of user connections. This commit utilize this endpoint and provide an interface to retrieve the list of user connections. Usages:

```ruby
Ribose::Connection.all
```