### PR TITLE
Add interface to retrieve user calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,17 @@ and it will return the connection as `Sawyer::Resource`.
 Ribose::Connection.all
 ```
 
+### Calendar
+
+#### List user calendars
+
+To retrieve the list of user calendar, we can use the `Calendar.all` and it will
+fetch the calendar details for the currently configured user.
+
+```ruby
+Ribose::Calendar.all
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/ribose.rb
+++ b/lib/ribose.rb
@@ -10,6 +10,7 @@ require "ribose/widget"
 require "ribose/stream"
 require "ribose/leaderboard"
 require "ribose/connection"
+require "ribose/calendar"
 
 module Ribose
   # Your code goes here...

--- a/lib/ribose/calendar.rb
+++ b/lib/ribose/calendar.rb
@@ -1,0 +1,12 @@
+module Ribose
+  class Calendar
+    # List User Calanders
+    #
+    # @param options [Hash] Query params as Hash
+    # @return [Sawyer::Resource]
+    #
+    def self.all(options = {})
+      Request.get("calendar/calendar", options)
+    end
+  end
+end

--- a/spec/fixtures/calendar.json
+++ b/spec/fixtures/calendar.json
@@ -1,0 +1,34 @@
+{
+  "filter": {
+    "enabled": [
+      19706,
+      19707
+    ],
+    "userSetting": []
+  },
+  "cal_info": [
+    {
+      "id": 19706,
+      "owner_type": "User",
+      "name": "john.doe",
+      "owner_id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+      "owner_name": "Personal",
+      "display_name": "john.doe (Personal)",
+      "can_manage": true,
+      "can_create_event": true
+    },
+    {
+      "id": 19707,
+      "owner_type": "Space",
+      "name": "Work",
+      "owner_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc",
+      "owner_name": "Work",
+      "display_name": "Work (Work)",
+      "can_manage": true,
+      "can_create_event": true
+    }
+  ],
+  "spaces_permission": {
+    "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc": true
+  }
+}

--- a/spec/ribose/calendar_spec.rb
+++ b/spec/ribose/calendar_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+RSpec.describe Ribose::Calendar do
+  describe ".all" do
+    it "retrieves the details for a calendar" do
+      stub_ribose_calendar_list_api
+      calendar = Ribose::Calendar.all
+
+      expect(calendar.cal_info.first.id).not_to be_nil
+      expect(calendar.cal_info.first.owner_type).to eq("User")
+      expect(calendar.cal_info.first.can_manage).to be_truthy
+    end
+  end
+
+  def stub_ribose_calendar_list_api
+    stub_api_response(:get, "calendar/calendar", filename: "calendar")
+  end
+end


### PR DESCRIPTION
Ribose API offers `/calendar` endpoint to retrieve the details for a user calender. This commit utilize this endpoint and exposes it through a very simple interface. To retrieve the list of calendar we can use the following.

```ruby
Ribose::Calendar.all
```