### PR TITLE
Interface to retrieve connection suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,15 @@ and it will return the connection as `Sawyer::Resource`.
 Ribose::Connection.all
 ```
 
+#### Connection suggestions
+
+To retrieve the list of connection suggestions we can use the following
+interface and it will retrieve the suggested users.
+
+```ruby
+Ribose::Connection.suggestions
+```
+
 ### Calendar
 
 #### List user calendars

--- a/lib/ribose/calendar.rb
+++ b/lib/ribose/calendar.rb
@@ -6,7 +6,7 @@ module Ribose
     # @return [Sawyer::Resource]
     #
     def self.all(options = {})
-      Request.get("calendar/calendar", options)
+      Request.get("calendar/calendar", query: options)
     end
   end
 end

--- a/lib/ribose/connection.rb
+++ b/lib/ribose/connection.rb
@@ -11,7 +11,17 @@ module Ribose
     # @return [Sawyer::Resource]
     #
     def self.all(options = {})
-      Request.get("people/connections", query: { s: "" }.merge(options))
+      options = { s: "" }.merge(options)
+      Request.get("people/connections", query: options)
+    end
+
+    # List connection suggestions
+    #
+    # @param options [Hash] Query parameters as a Hash
+    # @return [Array <Sawyer::Resource>]
+    #
+    def self.suggestions(options = {})
+      Request.get("people_finding", query: options).suggested_connection
     end
   end
 end

--- a/spec/fixtures/connection_suggestion.json
+++ b/spec/fixtures/connection_suggestion.json
@@ -1,0 +1,22 @@
+{
+  "suggested_connection": [
+    {
+      "id": "7275d94c-f308-57f3-9de0-a0e96e42e9b8",
+      "name": "Jennie Doe",
+      "connected": false,
+      "mutual_spaces": []
+    },
+    {
+      "id": "a41fa707-67e7-54e7-b50d-5f0edfd9ee17",
+      "name": "John Smith",
+      "connected": false,
+      "mutual_spaces": []
+    },
+    {
+      "id": "db0a2f2d-6241-4cdb-934a-1ac9e3deedd5",
+      "name": "Jonna Smith",
+      "connected": false,
+      "mutual_spaces": []
+    }
+  ]
+}

--- a/spec/ribose/connection_spec.rb
+++ b/spec/ribose/connection_spec.rb
@@ -14,7 +14,21 @@ RSpec.describe Ribose::Connection do
     end
   end
 
+  describe ".suggestions" do
+    it "retrieves the list of connection suggestions" do
+      stub_ribose_suggestion_list_api
+      suggestions = Ribose::Connection.suggestions
+
+      expect(suggestions.first.id).not_to be_nil
+      expect(suggestions.first.name).to eq("Jennie Doe")
+    end
+  end
+
   def stub_ribose_connection_list_api
     stub_api_response(:get, "people/connections?s=", filename: "connections")
+  end
+
+  def stub_ribose_suggestion_list_api
+    stub_api_response(:get, "people_finding", filename: "connection_suggestion")
   end
 end


### PR DESCRIPTION
This commits adds an interface, that we can use to retrieve the connection suggestions for any specific user. To retrieve the list we can use

```ruby
Ribose::Connection.suggestions
```