### PR TITLE
Add interface to fetch an app relation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,21 @@ Ribose::AppData.all
 
 ### App Relation
 
+#### List app relations
+
 To retrieve the list of app relations we can use the `AppRelation.all` interface
 
 ```ruby
 Ribose::AppRelation.all
+```
+
+#### Fetch an app relation
+
+To retrieve the details for a specific app relation, we can use the following
+interface
+
+```ruby
+Ribose::AppRelation.fetch(app_relation_id)
 ```
 
 ### Settings

--- a/lib/ribose/app_relation.rb
+++ b/lib/ribose/app_relation.rb
@@ -1,11 +1,21 @@
 module Ribose
   class AppRelation
-    include Ribose::Actions::All
+    # List App Relations
+    #
+    # @param options [Hash] Query params as a Hash
+    # @return [Array <Sawyer::Resource>]
+    #
+    def self.all(options = {})
+      Request.get("app_relations", query: options).app_relations
+    end
 
-    private
-
-    def resource_path
-      "app_relations"
+    # Fetch An App Relation
+    #
+    # @param app_relation_id [String] The App Relation Id.
+    # @return [Sawyer::Resource]
+    #
+    def self.fetch(app_relation_id)
+      Request.get("app_relations/#{app_relation_id}").app_relation
     end
   end
 end

--- a/spec/fixtures/app_relation.json
+++ b/spec/fixtures/app_relation.json
@@ -1,0 +1,19 @@
+{
+  "app_relation": {
+    "id": 123456789,
+    "app_name": "app/home",
+    "enabled": true,
+    "name": null,
+    "order_id": 0,
+    "used_storage": 0,
+    "owner_type": "User",
+    "owner_id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+    "system": true,
+    "app_type": "home",
+    "space_id": null,
+    "namespace": "home",
+    "show_in_menu?": true,
+    "uses_email_notifications?": false,
+    "searchable?": true
+  }
+}

--- a/spec/ribose/app_relation_spec.rb
+++ b/spec/ribose/app_relation_spec.rb
@@ -12,7 +12,26 @@ RSpec.describe Ribose::AppRelation do
     end
   end
 
+  describe ".fetch" do
+    it "fetches a specific app realtation details" do
+      relation_id = 123_456_789
+
+      stub_ribose_app_relation_find_api(relation_id)
+      app_relation = Ribose::AppRelation.fetch(relation_id)
+
+      expect(app_relation.id).to eq(relation_id)
+      expect(app_relation.owner_type).to eq("User")
+      expect(app_relation.app_name).to eq("app/home")
+    end
+  end
+
   def stub_ribose_app_relation_list_api
     stub_api_response(:get, "app_relations", filename: "app_relations")
+  end
+
+  def stub_ribose_app_relation_find_api(relation_id)
+    stub_api_response(
+      :get, "app_relations/#{relation_id}", filename: "app_relation"
+    )
   end
 end


### PR DESCRIPTION
This commit adds the interface to retrieve the details for a specific app relation. Usages:

```ruby
Ribose::AppRelation.fetch(app_relation_id)
```