### PR TITLE
Add interface to fetch a setting details

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,15 @@ return all of the user's settings.
 Ribose::Setting.all
 ```
 
+#### Fetch a setting
+
+To fetch the details for any specific settings we can use the `Setting.fetch`
+interface and it will return the details for that setting.
+
+```ruby
+Ribose::Setting.fetch(setting_id)
+```
+
 ### Spaces
 
 #### List user's spaces

--- a/lib/ribose/actions/all.rb
+++ b/lib/ribose/actions/all.rb
@@ -4,11 +4,20 @@ module Ribose
   module Actions
     module All
       extend Ribose::Actions::Base
-
-      def all
-        response = Ribose::Request.get(resource_path)
+      # List Resources
+      #
+      # Retrieve the list of resources via :get and then extract the
+      # the root element from the response object.
+      #
+      # @param options [Hash] Query parameters as a Hash
+      # @return [Array <Sawyer::Resource>]
+      #
+      def all(options = {})
+        response = Ribose::Request.get(resource_path, query: options)
         extract_root(response) || response
       end
+
+      private
 
       def resource_key
         resource_path
@@ -21,8 +30,17 @@ module Ribose
       end
 
       module ClassMethods
-        def all
-          new.all
+        # List Resources
+        #
+        # This exposes the instance method as class methods, and once
+        # invoked then it instantiate a new instance & invokes the all
+        # instance method with the provided parameters.
+        #
+        # @param options [Hash] Query parameters as Hash
+        # @return [Array <Sawyer::Resource>]
+        #
+        def all(options = {})
+          new.all(options)
         end
       end
     end

--- a/lib/ribose/app_relation.rb
+++ b/lib/ribose/app_relation.rb
@@ -1,13 +1,6 @@
 module Ribose
   class AppRelation
-    # List App Relations
-    #
-    # @param options [Hash] Query params as a Hash
-    # @return [Array <Sawyer::Resource>]
-    #
-    def self.all(options = {})
-      Request.get("app_relations", query: options).app_relations
-    end
+    include Ribose::Actions::All
 
     # Fetch An App Relation
     #
@@ -16,6 +9,12 @@ module Ribose
     #
     def self.fetch(app_relation_id)
       Request.get("app_relations/#{app_relation_id}").app_relation
+    end
+
+    private
+
+    def resource_path
+      "app_relations"
     end
   end
 end

--- a/lib/ribose/setting.rb
+++ b/lib/ribose/setting.rb
@@ -1,12 +1,22 @@
+require "ribose/actions"
+
 module Ribose
   class Setting
-    # List user setttings
+    include Ribose::Actions::All
+
+    # Fetch A Specific Setting
     #
-    # @param options [Hash] Query params as a Hash
-    # @return [Array <Sawyer::Resource>]
+    # @param setting_id [String] The setting Id
+    # @return [Sawyer::Resource]
     #
-    def self.all(options = {})
-      Request.get("settings", query: options).settings
+    def self.fetch(setting_id)
+      Request.get("settings/#{setting_id}").setting
+    end
+
+    private
+
+    def resource_path
+      "settings"
     end
   end
 end

--- a/spec/fixtures/setting.json
+++ b/spec/fixtures/setting.json
@@ -1,0 +1,16 @@
+{
+  "setting": {
+    "id": 123456789,
+    "type": "Setting::Personal",
+    "user_id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+    "time_zone": "Asia/Bangkok",
+    "help_getting_started": false,
+    "time_format": "%H:%M",
+    "date_format": "%Y-%m-%d",
+    "theme_id": "6",
+    "time_zone_offset": 7,
+    "time_zone_detected": "Asia/Bangkok",
+    "time_zone_offset_detected": 25200,
+    "time_zone_autodetect_status": 0
+  }
+}

--- a/spec/ribose/setting_spec.rb
+++ b/spec/ribose/setting_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe Ribose::Setting do
   describe ".all" do
-    it "lists all user's setttings" do
+    it "lists the user settings" do
       stub_ribose_setting_list_api
       settings = Ribose::Setting.all
 
@@ -10,5 +10,21 @@ RSpec.describe Ribose::Setting do
       expect(settings.first.type).to eq("Setting::Personal")
       expect(settings.first.time_zone_detected).to eq("Asia/Bangkok")
     end
+  end
+
+  describe ".fetch" do
+    it "fetches the details for a setting" do
+      setting_id = 123_456_789
+      stub_ribose_setting_find_api(setting_id)
+      setting = Ribose::Setting.fetch(setting_id)
+
+      expect(setting.id).to eq(setting_id)
+      expect(setting.type).to eq("Setting::Personal")
+      expect(setting.time_zone_detected).to eq("Asia/Bangkok")
+    end
+  end
+
+  def stub_ribose_setting_find_api(id)
+    stub_api_response(:get, "settings/#{id}", filename: "setting")
   end
 end


### PR DESCRIPTION
This commit adds the interface to retrieve the details for a specific settings. The interface is pretty simple, it expects us to provide a valid setting id and then returns the setting

```ruby
Ribose::Setting.fetch(setting_id)
```