### PR TITLE
Add interface to retrieve a space details

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ all of the spaces for the currently configured user.
 Ribose::Space.all
 ```
 
+#### Fetch a user space
+
+To retrieve the details for a space we can use the `Space.fetch(space_id)`.
+
+```ruby
+Ribose::Space.fetch(space_id)
+```
+
 ### Feeds
 
 #### List user feeds

--- a/lib/ribose.rb
+++ b/lib/ribose.rb
@@ -1,4 +1,5 @@
 require "ribose/version"
+require "ribose/base"
 require "ribose/config"
 require "ribose/request"
 require "ribose/setting"

--- a/lib/ribose/actions.rb
+++ b/lib/ribose/actions.rb
@@ -1,4 +1,5 @@
 require "ribose/actions/all"
+require "ribose/actions/fetch"
 
 module Ribose
   module Actions

--- a/lib/ribose/actions/all.rb
+++ b/lib/ribose/actions/all.rb
@@ -13,20 +13,37 @@ module Ribose
       # @return [Array <Sawyer::Resource>]
       #
       def all(options = {})
-        response = Ribose::Request.get(resource_path, query: options)
+        response = Ribose::Request.get(resources, options)
         extract_root(response) || response
       end
 
       private
 
-      def resource_key
-        resource_path
+      # Resources Key
+      #
+      # This value represents the root element in the API response.
+      # Currently, Ribose is using the plural resource name as the
+      # the key.
+      #
+      # By default we will use that to extract the details, but if
+      # some resource are different then we can override this and
+      # that will be used instead.
+      #
+      # @return [String]
+      #
+      def resources_key
+        resources.to_s
       end
 
       def extract_root(response)
-        unless resource_key.nil?
-          response[resource_key.to_s]
+        unless resources_key.nil?
+          response[resources_key]
         end
+      end
+
+      # Temporary - Not to break everything right away
+      def resources
+        resource_path
       end
 
       module ClassMethods
@@ -40,7 +57,7 @@ module Ribose
         # @return [Array <Sawyer::Resource>]
         #
         def all(options = {})
-          new.all(options)
+          new.all(query: options)
         end
       end
     end

--- a/lib/ribose/actions/fetch.rb
+++ b/lib/ribose/actions/fetch.rb
@@ -1,0 +1,56 @@
+require "ribose/actions/base"
+
+module Ribose
+  module Actions
+    module Fetch
+      extend Ribose::Actions::Base
+
+      # Fetch A Resource
+      #
+      # Retrieve the details for a specific resource via HTTP GET
+      # and retrurns those as `Sawyer::Resource`.
+      #
+      # @return [Sawyer::Resource]
+      #
+      def fetch
+        response = Request.get([resources, resource_id].join("/"))
+        extract_resource(response) || response
+      end
+
+      private
+
+      # Single Resource
+      #
+      # Returns the singular version of the resoruces, and if some
+      # resource usages different pattern then we can override this
+      # method and that return value will be used.
+      #
+      # @return [String]
+      #
+      def resource_key
+        resources[0...-1]
+      end
+
+      def extract_resource(response)
+        unless resource_key.nil?
+          response[resource_key.to_s]
+        end
+      end
+
+      module ClassMethods
+        # Fetch A Resource
+        #
+        # This exposes the `#fetch` instance method as class methods. Once
+        # this methods is invoked then it will create an instnace with all
+        # of the provided attributes & then invoke the `fetch` action on it
+        #
+        # @param resource_id [String] The specific resource Id
+        # @return [Sawyer::Resource]
+        #
+        def fetch(resource_id)
+          new(resource_id: resource_id).fetch
+        end
+      end
+    end
+  end
+end

--- a/lib/ribose/base.rb
+++ b/lib/ribose/base.rb
@@ -1,0 +1,16 @@
+module Ribose
+  class Base
+    def initialize(attributes = {})
+      @attributes = attributes
+      extract_base_attributes
+    end
+
+    private
+
+    attr_reader :resource_id, :attributes
+
+    def extract_base_attributes
+      @resource_id = attributes.delete(:resource_id)
+    end
+  end
+end

--- a/lib/ribose/space.rb
+++ b/lib/ribose/space.rb
@@ -1,12 +1,13 @@
 require "ribose/actions"
 
 module Ribose
-  class Space
+  class Space < Ribose::Base
     include Ribose::Actions::All
+    include Ribose::Actions::Fetch
 
     private
 
-    def resource_path
+    def resources
       "spaces"
     end
   end

--- a/spec/fixtures/space.json
+++ b/spec/fixtures/space.json
@@ -1,0 +1,59 @@
+{
+  "space": {
+    "id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc",
+    "name": "Work",
+    "created_at": "2017-07-27T07:19:09.000+00:00",
+    "invite_access": "admins",
+    "space_category_id": null,
+    "visibility": "invisible",
+    "group_email": "work57",
+    "default_role_id": 41592,
+    "join_requests_access": "disabled",
+    "active": true,
+    "description": "Client work related discussion",
+    "members_count": 1,
+    "admin": true,
+    "invitable_roles": [
+      {
+        "id": 41592,
+        "name": "Member",
+        "space_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc"
+      },
+      {
+        "id": 41593,
+        "name": "Administrator",
+        "space_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc"
+      },
+      {
+        "id": 41594,
+        "name": "Read only",
+        "space_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc"
+      }
+    ],
+    "owner": true,
+    "read_only": false,
+    "role_name": "Administrator",
+    "allow_invite": true,
+    "joined_at": "2017-07-27T07:19:09.000+00:00",
+    "access": "private",
+    "publishable?": false,
+    "user": {
+      "id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+      "name": "John Doe"
+    },
+    "owned_roles": [
+      {
+        "id": 41592,
+        "name": "Member"
+      },
+      {
+        "id": 41593,
+        "name": "Administrator"
+      },
+      {
+        "id": 41594,
+        "name": "Read only"
+      }
+    ]
+  }
+}

--- a/spec/ribose/actions/fetch_spec.rb
+++ b/spec/ribose/actions/fetch_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+require "ribose/actions/fetch"
+
+RSpec.describe "TestFetchAction" do
+  describe ".fetch" do
+    it "fetches a specific resource" do
+      resource_id = 123_456_789
+
+      stub_ribose_space_fetch_api(resource_id)
+      resource = Ribose::TestFetchAction.fetch(resource_id)
+
+      expect(resource.id).not_to be_nil
+      expect(resource.name).to eq("Work")
+    end
+  end
+
+  def stub_ribose_space_fetch_api(resource_id)
+    stub_api_response(:get, "spaces/#{resource_id}", filename: "space")
+  end
+
+  module Ribose
+    class TestFetchAction < Ribose::Base
+      include Ribose::Actions::Fetch
+
+      private
+
+      def resources
+        "spaces"
+      end
+    end
+  end
+end

--- a/spec/ribose/space_spec.rb
+++ b/spec/ribose/space_spec.rb
@@ -12,7 +12,24 @@ RSpec.describe Ribose::Space do
     end
   end
 
+  describe ".fetch" do
+    it "fetches a specific user space" do
+      space_id = 123_456_789
+
+      stub_ribose_space_fetch_api(space_id)
+      space = Ribose::Space.fetch(space_id)
+
+      expect(space.id).not_to be_nil
+      expect(space.name).to eq("Work")
+      expect(space.role_name).to eq("Administrator")
+    end
+  end
+
   def stub_ribose_space_list_api
     stub_api_response(:get, "spaces", filename: "spaces", status: 200)
+  end
+
+  def stub_ribose_space_fetch_api(space_id)
+    stub_api_response(:get, "spaces/#{space_id}", filename: "space")
   end
 end


### PR DESCRIPTION
This commit adds the interface to retrieve the details for a specific space, and this interface will return the `Sawyer::Resource`, which can be access as instance method or using `[]`.

This commit also extract the `fetch` action to a separate module, so from now on we only need to include that module and everything else should work as usual. Usage:

```ruby
Ribose::Space.fetch(space_id)
```