### PR TITLE
Add interface to retrieve space members

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,19 @@ To retrieve the details for a space we can use the `Space.fetch(space_id)`.
 Ribose::Space.fetch(space_id)
 ```
 
+### Members
+
+The members endpoint are space specific, to retrieve the member details under
+any specific space we can use this interface.
+
+### List of Members
+
+To retrieve the list of members, we can use the following interface.
+
+```ruby
+Ribose::Member.all(space_id, options)
+```
+
 ### Feeds
 
 #### List user feeds

--- a/lib/ribose.rb
+++ b/lib/ribose.rb
@@ -12,6 +12,7 @@ require "ribose/stream"
 require "ribose/leaderboard"
 require "ribose/connection"
 require "ribose/calendar"
+require "ribose/member"
 
 module Ribose
   # Your code goes here...

--- a/lib/ribose/base.rb
+++ b/lib/ribose/base.rb
@@ -3,11 +3,26 @@ module Ribose
     def initialize(attributes = {})
       @attributes = attributes
       extract_base_attributes
+      extract_local_attributes
     end
 
     private
 
     attr_reader :resource_id, :attributes
+
+    # Extract Local Attributes
+    #
+    # This hook method let us extract sub-class specific attributes
+    # And the way to do it is pretty simple, we only need to override
+    # this method and extract the keys from the attributes hash. For
+    # exmaple if `attributes` contains a has key `space_id` and we
+    # want to extract it to a sub-class then we can do it as follow
+    #
+    #   def extract_local_attributes
+    #     @space_id = attributes.delete(:space_id)
+    #   end
+    #
+    def extract_local_attributes; end
 
     def extract_base_attributes
       @resource_id = attributes.delete(:resource_id)

--- a/lib/ribose/member.rb
+++ b/lib/ribose/member.rb
@@ -1,0 +1,34 @@
+module Ribose
+  class Member < Ribose::Base
+    include Ribose::Actions::All
+
+    # List A Space Members
+    #
+    # This interface retrieves the list of members for any speicfic
+    # user spaces and then will return those as `Sawyer::Resource`
+    #
+    # @param space_id [String] The Space Id
+    # @param options [Hash] Query parameters as a Hash
+    # @return [Array<Sawyer::Resource>]
+    #
+    def self.all(space_id, options = {})
+      new(space_id: space_id, **options).all
+    end
+
+    private
+
+    attr_reader :space_id
+
+    def resources
+      ["spaces", space_id, "members"].join("/")
+    end
+
+    def resources_key
+      "spaces_users"
+    end
+
+    def extract_local_attributes
+      @space_id = attributes.delete(:space_id)
+    end
+  end
+end

--- a/spec/fixtures/members.json
+++ b/spec/fixtures/members.json
@@ -1,0 +1,20 @@
+{
+  "spaces_users": [
+    {
+      "id": 19625,
+      "user_id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+      "space_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc",
+      "role_name_in_space": "Administrator",
+      "user": {
+        "id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+        "owner": true,
+        "admin": true,
+        "connected": true,
+        "mutual_spaces": [
+          "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc"
+        ],
+        "name": "John Doe"
+      }
+    }
+  ]
+}

--- a/spec/ribose/member_spec.rb
+++ b/spec/ribose/member_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+
+RSpec.describe Ribose::Member do
+  describe ".all" do
+    it "retrieves all members for a space" do
+      space_id = 123_456_789
+      stub_ribose_space_member_list(space_id)
+
+      members = Ribose::Member.all(space_id)
+
+      expect(members.count).to eq(1)
+      expect(members.first.user.name).to eq("John Doe")
+      expect(members.first.role_name_in_space).to eq("Administrator")
+    end
+  end
+
+  def stub_ribose_space_member_list(space_id)
+    stub_api_response(:get, "spaces/#{space_id}/members", filename: "members")
+  end
+end


### PR DESCRIPTION
In a very high level, one Ribose Space contains multiple members, conversations, files, calendar, wiki and Polls, and this commit adds the interface to retrieve the Members from a specific space
To retrieve the Members we can use

```ruby
Ribose::Member.all(space_id)
```