### PR TITLE
Add interface to retrieve files for space

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,16 @@ To retrieve the list of members, we can use the following interface.
 Ribose::Member.all(space_id, options)
 ```
 
+### Files
+
+#### List of Files
+
+To retrieves the files for any specific space we can use the following interface
+
+```ruby
+Ribose::SpaceFile.all(space_id, options)
+```
+
 ### Feeds
 
 #### List user feeds

--- a/lib/ribose.rb
+++ b/lib/ribose.rb
@@ -13,6 +13,7 @@ require "ribose/leaderboard"
 require "ribose/connection"
 require "ribose/calendar"
 require "ribose/member"
+require "ribose/space_file"
 
 module Ribose
   # Your code goes here...

--- a/lib/ribose/space_file.rb
+++ b/lib/ribose/space_file.rb
@@ -1,0 +1,35 @@
+module Ribose
+  class SpaceFile < Ribose::Base
+    include Ribose::Actions::All
+
+    # List Files for Space
+    #
+    # This interface retrieves the files for any specific space, and
+    # the usages is pretty simple all we need to do, provide the space
+    # id and it will return the files as `Sawyer::Resource`
+    #
+    # @param space_id [String] The spcific space Id
+    # @param options [Hash] Query parameters as a Hash
+    # @return [Array<Sawyer::Resource>]
+    #
+    def self.all(space_id, options = {})
+      new(space_id: space_id, **options).all
+    end
+
+    private
+
+    attr_reader :space_id
+
+    def resources_key
+      "files"
+    end
+
+    def resources
+      ["spaces", space_id, "file", "files"].join("/")
+    end
+
+    def extract_local_attributes
+      @space_id = attributes.delete(:space_id)
+    end
+  end
+end

--- a/spec/fixtures/space_file.json
+++ b/spec/fixtures/space_file.json
@@ -1,0 +1,58 @@
+{
+  "files": [
+    {
+      "id": 9896,
+      "created_at": "2017-08-14T08:57:49.000+00:00",
+      "updated_at": "2017-08-14T08:57:50.000+00:00",
+      "name": "sample-file.png",
+      "description": "",
+      "version": 1,
+      "tag_list": [],
+      "content_size": 58784,
+      "content_type": "image/png",
+      "author": "Abu Nashir",
+      "allow_update": true,
+      "allow_create": true,
+      "allow_edit": true,
+      "allow_delete": true,
+      "allow_download": true,
+      "current_version_id": 11559,
+      "versions": [
+        {
+          "version": 1,
+          "name": "sample-file.png",
+          "updated_at": "2017-08-14T08:57:50.000+00:00",
+          "position": 1,
+          "current_version_id": 11559,
+          "icon_path": "https://assets-2-us-d1bd645.ribose.com/assets/files/placeholder-thumb-59ea90c30f07829d1dc87ce0dfffaeaf.png",
+          "content_size": 58784,
+          "author": "John Doe"
+        }
+      ]
+    }
+  ],
+  "recent_activity": [
+    {
+      "date": "Monday, August 14, 2017",
+      "links": [
+        {
+          "id": 9896,
+          "name": "sample-file.png",
+          "path": "/#spaces/0e8d5c16-1a31-4df9-83d9-eeaa374d5adc/file/files/9896/versions/11559"
+        }
+      ]
+    }
+  ],
+  "tags": {
+    "selected_tags": [],
+    "related_tags": [],
+    "all_tags": []
+  },
+  "permissions": {
+    "allow_create": true,
+    "allow_download": true,
+    "allow_edit": true,
+    "allow_delete": true,
+    "allow_mass_actions": true
+  }
+}

--- a/spec/ribose/space_file_spec.rb
+++ b/spec/ribose/space_file_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+
+RSpec.describe Ribose::SpaceFile do
+  describe ".all" do
+    it "retrieve files uploaded to a spce" do
+      space_id = 123_456_789
+      stub_ribose_space_file_list(space_id)
+
+      files = Ribose::SpaceFile.all(space_id)
+
+      expect(files.first.id).not_to be_nil
+      expect(files.first.name).to eq("sample-file.png")
+      expect(files.first.versions.first.version).to eq(1)
+    end
+  end
+
+  def stub_ribose_space_file_list(space_id)
+    stub_api_response(
+      :get, "spaces/#{space_id}/file/files", filename: "space_file"
+    )
+  end
+end


### PR DESCRIPTION
Ribose Space might contains multiple files, and this commit usages the `spaces/:space_id/file/files` endpoint and provides a very simple interface to retrieves the files for any space.

```ruby
Ribose::SpaceFile.all(space_id, options = {})
```