### PR TITLE
Expose testing related stubs with fixtures

### DIFF
--- a/lib/ribose.rb
+++ b/lib/ribose.rb
@@ -16,5 +16,7 @@ require "ribose/member"
 require "ribose/space_file"
 
 module Ribose
-  # Your code goes here...
+  def self.root
+    File.dirname(__dir__)
+  end
 end

--- a/lib/ribose/rspec.rb
+++ b/lib/ribose/rspec.rb
@@ -1,0 +1,19 @@
+# RSpec Test Helpers
+#
+# Actual API requests are slow and expensive and we try not to make
+# actual request when possible. For most of our tests we mock those
+# API call which verifies the endpoint, http verb and headers and
+# based on those it responses with an identical fixture file
+#
+# The main purpose of this file is to allow the user to use our test
+# helpers by simplify adding this file to their application and then
+# use the available helper  method when necessary.
+#
+# We do not require this module with the gem by default, but you can
+# do so by adding `require "ribose/rspec"` on top of `spec_helper`
+#
+require File.join(Ribose.root, "spec/support/fake_ribose_api.rb")
+
+RSpec.configure do |config|
+  config.include Ribose::FakeRiboseApi
+end

--- a/spec/ribose/app_data_spec.rb
+++ b/spec/ribose/app_data_spec.rb
@@ -12,8 +12,4 @@ RSpec.describe Ribose::AppData do
       expect(app_data.misc.capps.first.app_name).to eq("app/dashboard")
     end
   end
-
-  def stub_ribose_app_data_api
-    stub_api_response(:get, "app_data", filename: "app_data", status: 200)
-  end
 end

--- a/spec/ribose/app_relation_spec.rb
+++ b/spec/ribose/app_relation_spec.rb
@@ -24,14 +24,4 @@ RSpec.describe Ribose::AppRelation do
       expect(app_relation.app_name).to eq("app/home")
     end
   end
-
-  def stub_ribose_app_relation_list_api
-    stub_api_response(:get, "app_relations", filename: "app_relations")
-  end
-
-  def stub_ribose_app_relation_find_api(relation_id)
-    stub_api_response(
-      :get, "app_relations/#{relation_id}", filename: "app_relation"
-    )
-  end
 end

--- a/spec/ribose/calendar_spec.rb
+++ b/spec/ribose/calendar_spec.rb
@@ -11,8 +11,4 @@ RSpec.describe Ribose::Calendar do
       expect(calendar.cal_info.first.can_manage).to be_truthy
     end
   end
-
-  def stub_ribose_calendar_list_api
-    stub_api_response(:get, "calendar/calendar", filename: "calendar")
-  end
 end

--- a/spec/ribose/connection_spec.rb
+++ b/spec/ribose/connection_spec.rb
@@ -23,12 +23,4 @@ RSpec.describe Ribose::Connection do
       expect(suggestions.first.name).to eq("Jennie Doe")
     end
   end
-
-  def stub_ribose_connection_list_api
-    stub_api_response(:get, "people/connections?s=", filename: "connections")
-  end
-
-  def stub_ribose_suggestion_list_api
-    stub_api_response(:get, "people_finding", filename: "connection_suggestion")
-  end
 end

--- a/spec/ribose/feed_spec.rb
+++ b/spec/ribose/feed_spec.rb
@@ -11,10 +11,4 @@ RSpec.describe Ribose::Feed do
       expect(feeds.first.instance_name).to eq("John Doe")
     end
   end
-
-  private
-
-  def stub_ribose_feed_api
-    stub_api_response(:get, "feeds", filename: "feeds", status: 200)
-  end
 end

--- a/spec/ribose/leaderboard_spec.rb
+++ b/spec/ribose/leaderboard_spec.rb
@@ -10,10 +10,4 @@ RSpec.describe Ribose::Leaderboard do
       expect(leaderboard.first.login).to eq("john.doe")
     end
   end
-
-  def stub_ribose_leaderboard_api
-    stub_api_response(
-      :get, "activity_point/leaderboard", filename: "leaderboard", status: 200
-    )
-  end
 end

--- a/spec/ribose/member_spec.rb
+++ b/spec/ribose/member_spec.rb
@@ -13,8 +13,4 @@ RSpec.describe Ribose::Member do
       expect(members.first.role_name_in_space).to eq("Administrator")
     end
   end
-
-  def stub_ribose_space_member_list(space_id)
-    stub_api_response(:get, "spaces/#{space_id}/members", filename: "members")
-  end
 end

--- a/spec/ribose/setting_spec.rb
+++ b/spec/ribose/setting_spec.rb
@@ -23,8 +23,4 @@ RSpec.describe Ribose::Setting do
       expect(setting.time_zone_detected).to eq("Asia/Bangkok")
     end
   end
-
-  def stub_ribose_setting_find_api(id)
-    stub_api_response(:get, "settings/#{id}", filename: "setting")
-  end
 end

--- a/spec/ribose/space_file_spec.rb
+++ b/spec/ribose/space_file_spec.rb
@@ -13,10 +13,4 @@ RSpec.describe Ribose::SpaceFile do
       expect(files.first.versions.first.version).to eq(1)
     end
   end
-
-  def stub_ribose_space_file_list(space_id)
-    stub_api_response(
-      :get, "spaces/#{space_id}/file/files", filename: "space_file"
-    )
-  end
 end

--- a/spec/ribose/space_spec.rb
+++ b/spec/ribose/space_spec.rb
@@ -24,12 +24,4 @@ RSpec.describe Ribose::Space do
       expect(space.role_name).to eq("Administrator")
     end
   end
-
-  def stub_ribose_space_list_api
-    stub_api_response(:get, "spaces", filename: "spaces", status: 200)
-  end
-
-  def stub_ribose_space_fetch_api(space_id)
-    stub_api_response(:get, "spaces/#{space_id}", filename: "space")
-  end
 end

--- a/spec/ribose/stream_spec.rb
+++ b/spec/ribose/stream_spec.rb
@@ -11,8 +11,4 @@ RSpec.describe Ribose::Stream do
       expect(stream.notifications.first.data.first.info.action).to eq("create")
     end
   end
-
-  def stub_ribose_stream_list_api
-    stub_api_response(:get, "stream", filename: "stream", status: 200)
-  end
 end

--- a/spec/ribose/widget_spec.rb
+++ b/spec/ribose/widget_spec.rb
@@ -11,8 +11,4 @@ RSpec.describe Ribose::Widget do
       expect(widgets.first.type).to eq("Widget::RssFeed")
     end
   end
-
-  def stub_ribose_widget_list_api
-    stub_api_response(:get, "widgets", filename: "widgets", status: 200)
-  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,15 +1,13 @@
 require "webmock/rspec"
 require "bundler/setup"
 require "ribose"
+require "ribose/rspec"
 
 Dir["./spec/support/**/*.rb"].sort.each { |file| require file }
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
-
-  # Ribose API, Response stubs
-  config.include Ribose::FakeRiboseApi
 
   config.expect_with :rspec do |c|
     c.syntax = :expect

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -1,8 +1,73 @@
 module Ribose
   module FakeRiboseApi
+    def stub_ribose_space_list_api
+      stub_api_response(:get, "spaces", filename: "spaces")
+    end
+
+    def stub_ribose_space_fetch_api(space_id)
+      stub_api_response(:get, "spaces/#{space_id}", filename: "space")
+    end
+
+    def stub_ribose_feed_api
+      stub_api_response(:get, "feeds", filename: "feeds")
+    end
+
+    def stub_ribose_space_member_list(space_id)
+      stub_api_response(:get, "spaces/#{space_id}/members", filename: "members")
+    end
+
     def stub_ribose_setting_list_api
+      stub_api_response(:get, "settings", filename: "settings")
+    end
+
+    def stub_ribose_setting_find_api(id)
+      stub_api_response(:get, "settings/#{id}", filename: "setting")
+    end
+
+    def stub_ribose_stream_list_api
+      stub_api_response(:get, "stream", filename: "stream")
+    end
+
+    def stub_ribose_widget_list_api
+      stub_api_response(:get, "widgets", filename: "widgets")
+    end
+
+    def stub_ribose_calendar_list_api
+      stub_api_response(:get, "calendar/calendar", filename: "calendar")
+    end
+
+    def stub_ribose_app_data_api
+      stub_api_response(:get, "app_data", filename: "app_data")
+    end
+
+    def stub_ribose_space_file_list(space_id)
+      file_endppoint = ["spaces", space_id, "file", "files"].join("/")
+      stub_api_response(:get, file_endppoint, filename: "space_file")
+    end
+
+    def stub_ribose_leaderboard_api
       stub_api_response(
-        :get, "settings", filename: "settings", status: 200
+        :get, "activity_point/leaderboard", filename: "leaderboard"
+      )
+    end
+
+    def stub_ribose_app_relation_list_api
+      stub_api_response(:get, "app_relations", filename: "app_relations")
+    end
+
+    def stub_ribose_app_relation_find_api(relation_id)
+      stub_api_response(
+        :get, "app_relations/#{relation_id}", filename: "app_relation"
+      )
+    end
+
+    def stub_ribose_connection_list_api
+      stub_api_response(:get, "people/connections?s=", filename: "connections")
+    end
+
+    def stub_ribose_suggestion_list_api
+      stub_api_response(
+        :get, "people_finding", filename: "connection_suggestion"
       )
     end
 
@@ -39,8 +104,8 @@ module Ribose
     end
 
     def ribose_fixture(filename)
-      file_name = [filename, "json"].join(".")
-      file_path = File.join("../../", "fixtures", file_name)
+      filename = [filename, "json"].join(".")
+      file_path = File.join(Ribose.root, "spec", "fixtures", filename)
 
       File.read(File.expand_path(file_path, __FILE__))
     end


### PR DESCRIPTION
In the gem, we are stubbing all external API request at the moment But if any of our users wants to use those then they have to copy paste this or something, so let's take this one to the next label and expose all of our internal stubs as test helper.