### PR TITLE
WIP: Add interface to create user space

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Or
 
 ```ruby
 Ribose.configuration.api_token = "SECRET_API_TOKEN"
-Ribose.contribution.user_email = "your-email@example.com"
+Ribose.configuration.user_email = "your-email@example.com"
 ```
 
 ## Usage
@@ -121,6 +121,19 @@ To retrieve the details for a space we can use the `Space.fetch(space_id)`.
 
 ```ruby
 Ribose::Space.fetch(space_id)
+```
+
+#### Create a user space
+
+To create a new user space we can use
+
+```ruby
+Ribose::Space.create(
+  access: "private",
+  space_category_id: 12,
+  name: "The amazing Ribose Space",
+  description: "Description about your space"
+)
 ```
 
 ### Members

--- a/lib/ribose/request.rb
+++ b/lib/ribose/request.rb
@@ -36,6 +36,16 @@ module Ribose
       new(:get, endpoint, options).request
     end
 
+    # Make a HTTP POST Request
+    #
+    # @param endpoint [String] The relative API endpoint
+    # @param data [Hash] The request data as a Hash
+    # @return [Sawyer::Resource]
+    #
+    def self.post(endpoint, data)
+      new(:post, endpoint, data).request
+    end
+
     private
 
     attr_reader :data, :http_method
@@ -76,6 +86,7 @@ module Ribose
     def agent
       @agent ||= Sawyer::Agent.new(ribose_host, sawyer_options) do |http|
         http.headers[:accept] = "application/json"
+        http.headers[:content_type] = "application/json"
         http.headers["X-Indigo-Token"] = Ribose.configuration.api_token
         http.headers["X-Indigo-Email"] = Ribose.configuration.user_email
       end

--- a/lib/ribose/space.rb
+++ b/lib/ribose/space.rb
@@ -5,10 +5,28 @@ module Ribose
     include Ribose::Actions::All
     include Ribose::Actions::Fetch
 
+    def create
+      create_space[:space]
+    end
+
+    def self.create(name:, **attributes)
+      new(space: attributes.merge(name: name)).create
+    end
+
     private
+
+    attr_reader :space
 
     def resources
       "spaces"
+    end
+
+    def create_space
+      Ribose::Request.post(resources, space: space)
+    end
+
+    def extract_local_attributes
+      @space = attributes.delete(:space)
     end
   end
 end

--- a/spec/fixtures/space_created.json
+++ b/spec/fixtures/space_created.json
@@ -1,0 +1,59 @@
+{
+  "space": {
+    "id": "6b2741ad-4cde-4b4d-af3b-a162a4f6bc25",
+    "name": "Trip to the Mars",
+    "created_at": "2017-08-28T09:04:34.625+00:00",
+    "invite_access": "admins",
+    "space_category_id": 23,
+    "visibility": "invisible",
+    "group_email": "triptothemars",
+    "default_role_id": 41688,
+    "join_requests_access": "disabled",
+    "active": true,
+    "description": "The long awaited dream!",
+    "members_count": 1,
+    "admin": true,
+    "invitable_roles": [
+      {
+        "id": 41688,
+        "name": "Member",
+        "space_id": "6b2741ad-4cde-4b4d-af3b-a162a4f6bc25"
+      },
+      {
+        "id": 41689,
+        "name": "Administrator",
+        "space_id": "6b2741ad-4cde-4b4d-af3b-a162a4f6bc25"
+      },
+      {
+        "id": 41690,
+        "name": "Read only",
+        "space_id": "6b2741ad-4cde-4b4d-af3b-a162a4f6bc25"
+      }
+    ],
+    "owner": true,
+    "read_only": false,
+    "role_name": "Administrator",
+    "allow_invite": true,
+    "joined_at": "2017-08-28T09:04:34.000+00:00",
+    "access": "private",
+    "publishable?": false,
+    "user": {
+      "id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+      "name": "John Doe"
+    },
+    "owned_roles": [
+      {
+        "id": 41688,
+        "name": "Member"
+      },
+      {
+        "id": 41689,
+        "name": "Administrator"
+      },
+      {
+        "id": 41690,
+        "name": "Read only"
+      }
+    ]
+  }
+}

--- a/spec/ribose/request_spec.rb
+++ b/spec/ribose/request_spec.rb
@@ -12,7 +12,16 @@ RSpec.describe Ribose::Request do
     end
   end
 
-  def stub_ribose_ping_api_request
-    stub_api_response(:get, "ping", filename: "ping", status: 200)
+  describe ".post" do
+    it "submits provided data via :post" do
+      stub_ribose_ping_api_request(:post)
+      response = Ribose::Request.post("ping", data: "hello")
+
+      expect(response.data).to eq("Pong!")
+    end
+  end
+
+  def stub_ribose_ping_api_request(method = :get)
+    stub_api_response(method, "ping", filename: "ping", status: 200)
   end
 end

--- a/spec/ribose/space_spec.rb
+++ b/spec/ribose/space_spec.rb
@@ -24,4 +24,24 @@ RSpec.describe Ribose::Space do
       expect(space.role_name).to eq("Administrator")
     end
   end
+
+  describe ".create" do
+    it "creates a new space with provided details" do
+      stub_ribose_space_create_api(space_attributes)
+      space = Ribose::Space.create(space_attributes)
+
+      expect(space.id).not_to be_nil
+      expect(space.visibility).to eq("invisible")
+      expect(space.name).to eq("Trip to the Mars")
+    end
+  end
+
+  def space_attributes
+    {
+      access: "private",
+      space_category_id: 12,
+      description: "The long awaited dream!",
+      name: "Trip to the Mars",
+    }
+  end
 end

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -4,6 +4,12 @@ module Ribose
       stub_api_response(:get, "spaces", filename: "spaces")
     end
 
+    def stub_ribose_space_create_api(attributes)
+      stub_api_response(
+        :post, "spaces", data: { space: attributes }, filename: "space_created"
+      )
+    end
+
     def stub_ribose_space_fetch_api(space_id)
       stub_api_response(:get, "spaces/#{space_id}", filename: "space")
     end


### PR DESCRIPTION
Ribose discussions are organized based on spaces, and normally one user will be associated with one or more spaces and they can also create a new space when necessary.

This commit adds the interface to create a new user space, and it is pretty simple, all we need to do is provide the details and it will then return the newly created space on success.

```ruby
Ribose::Space.create(
  access: "private",
  space_category_id: 12,
  name: "The amazing Ribose Space",
  description: "Description about your space"
)
```