### PR TITLE
Add support to log connection information

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Ribose.configure do |config|
   # There are also some default configurations, normally you do not need to
   # change those unless you have some very specific use case scenario.
   #
+  # config.debug_mode = false
   # config.api_host = "www.ribose.com"
 end
 ```

--- a/lib/ribose/configuration.rb
+++ b/lib/ribose/configuration.rb
@@ -1,9 +1,14 @@
 module Ribose
   class Configuration
-    attr_accessor :api_host, :api_token, :user_email
+    attr_accessor :api_host, :api_token, :user_email, :debug_mode
 
     def initialize
+      @debug_mode = false
       @api_host ||= "www.ribose.com"
+    end
+
+    def debug_mode?
+      debug_mode == true
     end
   end
 end

--- a/lib/ribose/request.rb
+++ b/lib/ribose/request.rb
@@ -1,3 +1,4 @@
+require "faraday"
 require "sawyer"
 
 module Ribose
@@ -57,7 +58,19 @@ module Ribose
     end
 
     def sawyer_options
-      { links_parser: Sawyer::LinkParsers::Simple.new }
+      {
+        links_parser: Sawyer::LinkParsers::Simple.new,
+        faraday: Faraday.new(builder: custom_builder),
+      }
+    end
+
+    def custom_builder
+      if Ribose.configuration.debug_mode?
+        Faraday::RackBuilder.new do |builder|
+          builder.response :logger, nil, bodies: true
+          builder.adapter Faraday.default_adapter
+        end
+      end
     end
 
     def agent

--- a/spec/ribose/config_spec.rb
+++ b/spec/ribose/config_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Ribose::Config do
       end
 
       expect(Ribose.configuration.api_host).to eq(api_host)
+      expect(Ribose.configuration.debug_mode?).to be_falsey
       expect(Ribose.configuration.api_token).to eq(api_token)
       expect(Ribose.configuration.user_email).to eq(user_email)
     end


### PR DESCRIPTION
Currently, we don't have any way to debug the communication between our gem and the server, but in the development sometime it becomes an important issue to see whats the API client is doing underneath

This commit usages the `faraday` middleware builder to plug in a debugger, and by default it is disabled but we can easily turn it on using the following configuration.

```ruby
Ribose.configuration.debug_mode = true
```