### PR TITLE
Add interface to list space conversations

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,14 @@ To retrieves the files for any specific space we can use the following interface
 Ribose::SpaceFile.all(space_id, options)
 ```
 
+### Conversations
+
+#### Listing Space Conversations
+
+```ruby
+Ribose::Conversation.all(space_id, options = {})
+```
+
 ### Feeds
 
 #### List user feeds

--- a/lib/ribose.rb
+++ b/lib/ribose.rb
@@ -14,6 +14,7 @@ require "ribose/connection"
 require "ribose/calendar"
 require "ribose/member"
 require "ribose/space_file"
+require "ribose/conversation"
 
 module Ribose
   def self.root

--- a/lib/ribose/conversation.rb
+++ b/lib/ribose/conversation.rb
@@ -1,0 +1,27 @@
+module Ribose
+  class Conversation < Ribose::Base
+    include Ribose::Actions::All
+
+    # Listing Space Conversations
+    #
+    # @param space_id [String] The Space UUID
+    # @param options [Hash] Query parameters as a Hash
+    # @return [Array <Sawyer::Resource>]
+    #
+    def self.all(space_id, options = {})
+      new(space_id: space_id, **options).all
+    end
+
+    private
+
+    attr_reader :space_id
+
+    def extract_local_attributes
+      @space_id = attributes.delete(:space_id)
+    end
+
+    def resources
+      ["spaces", space_id, "conversation", "conversations"].join("/")
+    end
+  end
+end

--- a/spec/fixtures/conversations.json
+++ b/spec/fixtures/conversations.json
@@ -1,0 +1,34 @@
+{
+  "conversations": [
+    {
+      "id": "741ebd0f-0959-42c5-b7d3-7749666d2f5f",
+      "space_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc",
+      "created_at": "2017-09-02T09:06:31.000+00:00",
+      "updated_at": "2017-09-02T09:06:31.000+00:00",
+      "name": "Sample conversation",
+      "tag_list": [
+        "sample",
+        "conversation"
+      ],
+      "published": false,
+      "is_favorite": false,
+      "is_read": true,
+      "allow_publish": false,
+      "number_of_messages": 0,
+      "allow_edit": true,
+      "allow_delete": true,
+      "allow_comment": true,
+      "contents": "",
+      "attachments_listed": [],
+      "all_attachments": [],
+      "user": {
+        "id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+        "name": "John Doe",
+        "connected": true,
+        "mutual_spaces": [
+          "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc"
+        ]
+      }
+    }
+  ]
+}

--- a/spec/ribose/conversation_spec.rb
+++ b/spec/ribose/conversation_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+RSpec.describe Ribose::Conversation do
+  describe ".all" do
+    it "retrieves the conversations for a space" do
+      space_id = 123_456_789
+
+      stub_ribose_space_conversation_list(space_id)
+      conversations = Ribose::Conversation.all(space_id)
+
+      expect(conversations.first.id).not_to be_nil
+      expect(conversations.first.number_of_messages).to eq(0)
+      expect(conversations.first.name).to eq("Sample conversation")
+    end
+  end
+end

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -57,6 +57,11 @@ module Ribose
       stub_api_response(:get, file_endppoint, filename: "space_file")
     end
 
+    def stub_ribose_space_conversation_list(space_id)
+      conversation_path = "spaces/#{space_id}/conversation/conversations"
+      stub_api_response(:get, conversation_path, filename: "conversations")
+    end
+
     def stub_ribose_leaderboard_api
       stub_api_response(
         :get, "activity_point/leaderboard", filename: "leaderboard"


### PR DESCRIPTION
The conversations in Ribose happens under a user spaces. Two or more user can participate in those conversations.

This commit adds the interface to retrieves the conversations for any of the existing space. Usages:

```ruby
Ribose::Conversation.all(space_id, options = {})
```