### PR TITLE
Add to support to create a conversation

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,14 @@ Ribose::SpaceFile.all(space_id, options)
 Ribose::Conversation.all(space_id, options = {})
 ```
 
+#### Create A New Conversation
+
+```ruby
+Ribose::Conversation.create(
+  space_id, name: "Sample conversation", tag_list: "sample, conversation"
+)
+```
+
 ### Feeds
 
 #### List user feeds

--- a/lib/ribose/conversation.rb
+++ b/lib/ribose/conversation.rb
@@ -2,6 +2,10 @@ module Ribose
   class Conversation < Ribose::Base
     include Ribose::Actions::All
 
+    def create
+      create_conversation[:conversation]
+    end
+
     # Listing Space Conversations
     #
     # @param space_id [String] The Space UUID
@@ -10,6 +14,16 @@ module Ribose
     #
     def self.all(space_id, options = {})
       new(space_id: space_id, **options).all
+    end
+
+    # Create A New Conversation
+    #
+    # @param space_id [String] The Space UUID
+    # @param attributes [Hash] The conversation attributes
+    # @return [Sawyer::Resource]
+    #
+    def self.create(space_id, attributes)
+      new(attributes.merge(space_id: space_id)).create
     end
 
     private
@@ -22,6 +36,12 @@ module Ribose
 
     def resources
       ["spaces", space_id, "conversation", "conversations"].join("/")
+    end
+
+    def create_conversation
+      Ribose::Request.post(
+        resources, conversation: attributes.merge(space_id: space_id)
+      )
     end
   end
 end

--- a/spec/fixtures/conversation_created.json
+++ b/spec/fixtures/conversation_created.json
@@ -1,0 +1,31 @@
+{
+  "conversation": {
+    "id": "ee50bb3c-ed79-4efc-821a-64926f645bfb",
+    "space_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc",
+    "created_at": "2017-09-03T07:16:51.053+00:00",
+    "updated_at": "2017-09-03T07:16:51.053+00:00",
+    "name": "Sample Conversation",
+    "tag_list": [
+      "sample",
+      "conversation"
+    ],
+    "published": false,
+    "is_favorite": false,
+    "is_read": true,
+    "allow_publish": false,
+    "number_of_messages": 0,
+    "allow_edit": true,
+    "allow_delete": true,
+    "allow_comment": true,
+    "contents": "",
+    "attachments_listed": [],
+    "user": {
+      "id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+      "name": "John Doe",
+      "connected": true,
+      "mutual_spaces": [
+        "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc"
+      ]
+    }
+  }
+}

--- a/spec/ribose/conversation_spec.rb
+++ b/spec/ribose/conversation_spec.rb
@@ -13,4 +13,25 @@ RSpec.describe Ribose::Conversation do
       expect(conversations.first.name).to eq("Sample conversation")
     end
   end
+
+  describe ".create" do
+    it "creates a new conversation into a space" do
+      space_id = 123_456_789
+
+      stub_ribose_space_conversation_create(space_id, conversation_attrs)
+      conversation = Ribose::Conversation.create(space_id, conversation_attrs)
+
+      expect(conversation.id).not_to be_nil
+      expect(conversation.name).to eq("Sample Conversation")
+      expect(conversation.tag_list).to eq(["sample", "conversation"])
+    end
+  end
+
+  def conversation_attrs
+    {
+      name: "Sample Conversation",
+      tag_list: "sample, conversation",
+      space_id: 123456789,
+    }
+  end
 end

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -62,6 +62,17 @@ module Ribose
       stub_api_response(:get, conversation_path, filename: "conversations")
     end
 
+    def stub_ribose_space_conversation_create(space_id, attributes)
+      conversation_path = "spaces/#{space_id}/conversation/conversations"
+
+      stub_api_response(
+        :post,
+        conversation_path,
+        filename: "conversation_created",
+        data: { conversation: attributes },
+      )
+    end
+
     def stub_ribose_leaderboard_api
       stub_api_response(
         :get, "activity_point/leaderboard", filename: "leaderboard"


### PR DESCRIPTION
Ribose conversation endpoint supports the creation of a new conversation in any space, this commit utilize this endpoint and provides an easier interface to create new conversation through client. Usages:

```ruby
Ribose::Conversation.create(
 space_id,
 name: "Sample Conversation", tag_list: "sample, conversation"
)
```