### PR TITLE
Remove a conversation from a Space

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,12 @@ Ribose::Conversation.create(
 )
 ```
 
+### Remove A Conversation
+
+```ruby
+Ribose::Conversation.remove(space_id: "space_id", conversation_id: "12345")
+```
+
 ### Feeds
 
 #### List user feeds

--- a/lib/ribose/conversation.rb
+++ b/lib/ribose/conversation.rb
@@ -6,6 +6,10 @@ module Ribose
       create_conversation[:conversation]
     end
 
+    def remove
+      Ribose::Request.delete([resources, conversation_id].join("/"))
+    end
+
     # Listing Space Conversations
     #
     # @param space_id [String] The Space UUID
@@ -26,12 +30,17 @@ module Ribose
       new(attributes.merge(space_id: space_id)).create
     end
 
+    def self.remove(space_id:, conversation_id:)
+      new(space_id: space_id, conversation_id: conversation_id).remove
+    end
+
     private
 
-    attr_reader :space_id
+    attr_reader :space_id, :conversation_id
 
     def extract_local_attributes
       @space_id = attributes.delete(:space_id)
+      @conversation_id = attributes.delete(:conversation_id)
     end
 
     def resources

--- a/lib/ribose/request.rb
+++ b/lib/ribose/request.rb
@@ -46,6 +46,15 @@ module Ribose
       new(:post, endpoint, data).request
     end
 
+    # Make a HTTP DELETE Request
+    #
+    # @param endpoint [String] The relative API endpoint
+    # @return [Sawyer::Resource]
+    #
+    def self.delete(endpoint, options = {})
+      new(:delete, endpoint, options).request
+    end
+
     private
 
     attr_reader :data, :http_method

--- a/spec/ribose/conversation_spec.rb
+++ b/spec/ribose/conversation_spec.rb
@@ -27,6 +27,20 @@ RSpec.describe Ribose::Conversation do
     end
   end
 
+  describe ".remove" do
+    it "remvoes a conversation from a space" do
+      space_id = 123456789
+      conversation_id = 987_654_321
+
+      stub_ribose_space_conversation_remove(space_id, conversation_id)
+
+      expect do
+        Ribose::Conversation.
+          remove(space_id: space_id, conversation_id: conversation_id)
+      end.not_to raise_error
+    end
+  end
+
   def conversation_attrs
     {
       name: "Sample Conversation",

--- a/spec/ribose/request_spec.rb
+++ b/spec/ribose/request_spec.rb
@@ -21,6 +21,15 @@ RSpec.describe Ribose::Request do
     end
   end
 
+  describe ".delete" do
+    it "creates a http request via :delete" do
+      stub_ribose_ping_api_request(:delete)
+      response = Ribose::Request.delete("ping")
+
+      expect(response.data).to eq("Pong!")
+    end
+  end
+
   def stub_ribose_ping_api_request(method = :get)
     stub_api_response(method, "ping", filename: "ping", status: 200)
   end

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -73,6 +73,11 @@ module Ribose
       )
     end
 
+    def stub_ribose_space_conversation_remove(space_id, conversation_id)
+      path = "spaces/#{space_id}/conversation/conversations/#{conversation_id}"
+      stub_api_response(:delete, path, filename: "empty", status: 200)
+    end
+
     def stub_ribose_leaderboard_api
       stub_api_response(
         :get, "activity_point/leaderboard", filename: "leaderboard"


### PR DESCRIPTION
The Ribose API offers an endpoint to remove a conversation, this commit utilize that endpoint and add a simpler interface to remove any conversation from a user space. Usages:

```ruby
Ribose::Conversation.remove(
  space_id: "The Space UUID",
  conversation_id: "The Conversation UUID"
)
```