### PR TITLE
Add support to list conversation messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,10 +183,18 @@ Ribose::Conversation.create(
 )
 ```
 
-### Remove A Conversation
+#### Remove A Conversation
 
 ```ruby
 Ribose::Conversation.remove(space_id: "space_id", conversation_id: "12345")
+```
+
+### Message
+
+#### List Conversation Messages
+
+```ruby
+Ribose::Message.all(space_id: space_uuid, conversation_id: conversation_uuid)
 ```
 
 ### Feeds

--- a/lib/ribose.rb
+++ b/lib/ribose.rb
@@ -15,6 +15,7 @@ require "ribose/calendar"
 require "ribose/member"
 require "ribose/space_file"
 require "ribose/conversation"
+require "ribose/message"
 
 module Ribose
   def self.root

--- a/lib/ribose/message.rb
+++ b/lib/ribose/message.rb
@@ -1,0 +1,33 @@
+module Ribose
+  class Message < Ribose::Base
+    include Ribose::Actions::All
+
+    # Listing Conversation Messages
+    #
+    # @param space_id [String] The Space UUID
+    # @param conversation_id [String] The Conversation UUID
+    # @param options [Hash] The Query parameters as a Hash
+    # @return [Array<Sawyer::Resource>]
+    #
+    def self.all(space_id:, conversation_id:, **options)
+      new(space_id: space_id, conversation_id: conversation_id, **options).all
+    end
+
+    private
+
+    attr_reader :space_id, :conversation_id
+
+    def extract_local_attributes
+      @space_id = attributes.delete(:space_id)
+      @conversation_id = attributes.delete(:conversation_id)
+    end
+
+    def resources
+      [conversations, conversation_id, "messages"].join("/")
+    end
+
+    def conversations
+      ["spaces", space_id, "conversation/conversations"].join("/")
+    end
+  end
+end

--- a/spec/fixtures/messages.json
+++ b/spec/fixtures/messages.json
@@ -1,0 +1,24 @@
+{
+  "messages": [
+    {
+      "id": "eec38935-3070-4949-b217-878aa07db699",
+      "conversation_id": "0c88ffab-bc5e-4243-86cc-584df87f192b",
+      "created_at": "2017-09-04T07:30:48.000+00:00",
+      "updated_at": "2017-09-04T07:30:48.000+00:00",
+      "contents": "Welcome to Ribose Space",
+      "attachments_listed": [],
+      "attachments_inline": [],
+      "allow_edit": true,
+      "allow_delete": true,
+      "user": {
+        "id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+        "name": "John Doe",
+        "connected": true,
+        "mutual_spaces": [
+          "268b0407-c3a3-4aad-8693-fdba789f7f0d",
+          "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc"
+        ]
+      }
+    }
+  ]
+}

--- a/spec/ribose/message_spec.rb
+++ b/spec/ribose/message_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+RSpec.describe Ribose::Message do
+  describe ".all" do
+    it "retrieves all conversation messages" do
+      space_id = 123_456
+      conversation_id = 456_789
+      stub_ribose_message_list(space_id, conversation_id)
+
+      messages = Ribose::Message.all(
+        space_id: space_id, conversation_id: conversation_id,
+      )
+
+      expect(messages.first.id).not_to be_nil
+      expect(messages.first.user.name).to eq("John Doe")
+      expect(messages.first.contents).to eq("Welcome to Ribose Space")
+    end
+  end
+end

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -78,6 +78,11 @@ module Ribose
       stub_api_response(:delete, path, filename: "empty", status: 200)
     end
 
+    def stub_ribose_message_list(sid, cid)
+      message_path = "spaces/#{sid}/conversation/conversations/#{cid}/messages"
+      stub_api_response(:get, message_path, filename: "messages", status: 200)
+    end
+
     def stub_ribose_leaderboard_api
       stub_api_response(
         :get, "activity_point/leaderboard", filename: "leaderboard"


### PR DESCRIPTION
Each Ribose conversation includes some messages and Ribose also offers an API endpoint to retrieve those messages. This commit usages that endpoint and provide a simpler interface to retrieve those conversation messages.

```ruby
Ribose::Message.all(
  space_id: space_uuid,
  conversation_id: conversation_uuid,
)
```