### PR TITLE
Add support to add a message to conversation

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,16 @@ Ribose::Conversation.remove(space_id: "space_id", conversation_id: "12345")
 Ribose::Message.all(space_id: space_uuid, conversation_id: conversation_uuid)
 ```
 
+#### Create a new message
+
+```ruby
+Ribose::Message.create(
+  space_id: space_uuid,
+  conversation_id: conversation_uuid,
+  contents: "Provide your message body here",
+)
+```
+
 ### Feeds
 
 #### List user feeds

--- a/lib/ribose/message.rb
+++ b/lib/ribose/message.rb
@@ -2,6 +2,10 @@ module Ribose
   class Message < Ribose::Base
     include Ribose::Actions::All
 
+    def create
+      create_message[:message]
+    end
+
     # Listing Conversation Messages
     #
     # @param space_id [String] The Space UUID
@@ -11,6 +15,21 @@ module Ribose
     #
     def self.all(space_id:, conversation_id:, **options)
       new(space_id: space_id, conversation_id: conversation_id, **options).all
+    end
+
+    # Create A New Message
+    #
+    # @param space_id [String] The Space UUID
+    # @param conversation_id [String] The Conversation UUID
+    # @param attributes [Hash] The conversation attributes
+    # @return [Sawyer::Resource]
+    #
+    def self.create(space_id:, conversation_id:, **attributes)
+      message_attributes = attributes.merge(
+        space_id: space_id, conversation_id: conversation_id,
+      )
+
+      new(message_attributes).create
     end
 
     private
@@ -28,6 +47,12 @@ module Ribose
 
     def conversations
       ["spaces", space_id, "conversation/conversations"].join("/")
+    end
+
+    def create_message
+      Ribose::Request.post(
+        resources, message: attributes.merge(conversation_id: conversation_id)
+      )
     end
   end
 end

--- a/spec/fixtures/message_created.json
+++ b/spec/fixtures/message_created.json
@@ -1,0 +1,22 @@
+{
+  "message": {
+    "id": "9af4df9f-2a30-4d66-a925-efaf45057ae4",
+    "conversation_id": "0c88ffab-bc5e-4243-86cc-584df87f192b",
+    "created_at": "2017-09-04T09:46:42.223+00:00",
+    "updated_at": "2017-09-04T09:46:42.223+00:00",
+    "contents": "Welcome to Ribose",
+    "attachments_listed": [],
+    "attachments_inline": [],
+    "allow_edit": true,
+    "allow_delete": true,
+    "user": {
+      "id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+      "name": "John Doe",
+      "connected": true,
+      "mutual_spaces": [
+        "268b0407-c3a3-4aad-8693-fdba789f7f0d",
+        "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc"
+      ]
+    }
+  }
+}

--- a/spec/ribose/message_spec.rb
+++ b/spec/ribose/message_spec.rb
@@ -16,4 +16,30 @@ RSpec.describe Ribose::Message do
       expect(messages.first.contents).to eq("Welcome to Ribose Space")
     end
   end
+
+  describe ".create" do
+    it "creates a new message into a conversation" do
+      space_id = 123_456
+
+      stub_ribose_message_create(space_id, message: message_attrs)
+      message = Ribose::Message.create(message_attrs.merge(space_id: space_id))
+
+      expect(message.id).not_to be_nil
+      expect(message.user.name).to eq("John Doe")
+      expect(message.contents).to eq("Welcome to Ribose")
+    end
+  end
+
+  def message_attrs
+    { contents: "Welcome to Ribose", conversation_id: "456789" }
+  end
+
+  def stub_ribose_message_create(sid, attributes)
+    cid = attributes[:message][:conversation_id]
+    message_path = "spaces/#{sid}/conversation/conversations/#{cid}/messages"
+
+    stub_api_response(
+      :post, message_path, data: attributes, filename: "message_created"
+    )
+  end
 end


### PR DESCRIPTION
This commit utilize the message creation endpoint and provides an interface to add a new message to an existing conversation. Please refer to the Readme / API Doc to find out the supported attributes. Basic usages:

```ruby
Ribose::Message.create(
  space_id: space_uuid,
  conversation_id: conversation_uuid,
  contents: "The message body for your message",
)
```