### PR TITLE
Add support to remove a conversation message

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,16 @@ Ribose::Message.update(
 )
 ```
 
+#### Remove a message
+
+```ruby
+Ribose::Message.remove(
+  space_id: space_uuid,
+  message_id: message_uuid,
+  conversation_id: conversation_uuid,
+)
+```
+
 ### Feeds
 
 #### List user feeds

--- a/lib/ribose/message.rb
+++ b/lib/ribose/message.rb
@@ -10,6 +10,10 @@ module Ribose
       update_message[:message]
     end
 
+    def remove
+      Ribose::Request.delete([resources, message_id].join("/"))
+    end
+
     # Listing Conversation Messages
     #
     # @param space_id [String] The Space UUID
@@ -36,7 +40,7 @@ module Ribose
       new(message_attributes).create
     end
 
-    # Update an existing messsage
+    # Update A Messsage
     #
     # @param space_id [String] The Space UUID
     # @param message_id [String] The Message UUID
@@ -52,6 +56,21 @@ module Ribose
       )
 
       new(message_attributes).update
+    end
+
+    # Remove A Message
+    #
+    # @param space_id [String] The Space UUID
+    # @param message_id [String] The Message UUID
+    # @param conversation_id [String] The Conversation UUID
+    # @return [Sawyer::Resource]
+    #
+    def self.remove(space_id:, message_id:, conversation_id:)
+      new(
+        space_id: space_id,
+        message_id: message_id,
+        conversation_id: conversation_id,
+      ).remove
     end
 
     private

--- a/spec/ribose/message_spec.rb
+++ b/spec/ribose/message_spec.rb
@@ -45,6 +45,24 @@ RSpec.describe Ribose::Message do
     end
   end
 
+  describe ".remove" do
+    it "remvoes a message from the conversation" do
+      space_id = 123_456
+      message_id = 789_012_345
+      conversation_id = 9282737373
+
+      stub_ribose_message_remove(space_id, message_id, conversation_id)
+
+      expect do
+        Ribose::Message.remove(
+          space_id: space_id,
+          message_id: message_id,
+          conversation_id: conversation_id,
+        )
+      end.not_to raise_error
+    end
+  end
+
   def message_attrs
     { contents: "Welcome to Ribose", conversation_id: "456789" }
   end

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -95,6 +95,11 @@ module Ribose
       stub_api_response(:put, path, data: attributes, filename: "message")
     end
 
+    def stub_ribose_message_remove(space_id, message_id, conversation_id)
+      path = [messages_path(space_id, conversation_id), message_id].join("/")
+      stub_api_response(:delete, path, filename: "empty", status: 200)
+    end
+
     def stub_ribose_leaderboard_api
       stub_api_response(
         :get, "activity_point/leaderboard", filename: "leaderboard"


### PR DESCRIPTION
Ribose API offers and API endpoint to remove any of the existing messages, and this commit utilize that endpoint to provide the `.remove` interface to remove a message. Usages:

```ruby
Ribose::Message.remove(
  space_id: space_uuid,
  message_id: message_uuid,
  conversation_id: conversation_uuid,
)
```