### PR TITLE
Remove `all` action related duplications

### DIFF
--- a/lib/ribose/calendar.rb
+++ b/lib/ribose/calendar.rb
@@ -1,12 +1,11 @@
 module Ribose
-  class Calendar
-    # List User Calanders
-    #
-    # @param options [Hash] Query params as Hash
-    # @return [Sawyer::Resource]
-    #
-    def self.all(options = {})
-      Request.get("calendar/calendar", query: options)
+  class Calendar < Ribose::Base
+    include Ribose::Actions::All
+
+    private
+
+    def resources
+      "calendar/calendar"
     end
   end
 end

--- a/lib/ribose/connection.rb
+++ b/lib/ribose/connection.rb
@@ -1,5 +1,7 @@
 module Ribose
-  class Connection
+  class Connection < Ribose::Base
+    include Ribose::Actions::All
+
     # List Connections
     #
     # Note: Currently, There are some chaching in place for this endpoint
@@ -11,8 +13,7 @@ module Ribose
     # @return [Sawyer::Resource]
     #
     def self.all(options = {})
-      options = { s: "" }.merge(options)
-      Request.get("people/connections", query: options)
+      new.all(options.merge(query: { s: "" }))
     end
 
     # List connection suggestions
@@ -22,6 +23,12 @@ module Ribose
     #
     def self.suggestions(options = {})
       Request.get("people_finding", query: options).suggested_connection
+    end
+
+    private
+
+    def resources
+      "people/connections"
     end
   end
 end


### PR DESCRIPTION
We have extracted `all` action to a module to make things simpler but there are still some resources that is still redefining this method individually.

This commit removes those duplications and replaced those by the new `Ribose::Actions::All` module.