### PR TITLE
Remove `create` action related duplications

### DIFF
--- a/lib/ribose/actions.rb
+++ b/lib/ribose/actions.rb
@@ -1,5 +1,6 @@
 require "ribose/actions/all"
 require "ribose/actions/fetch"
+require "ribose/actions/create"
 
 module Ribose
   module Actions

--- a/lib/ribose/actions/create.rb
+++ b/lib/ribose/actions/create.rb
@@ -1,0 +1,47 @@
+require "ribose/actions/base"
+
+module Ribose
+  module Actions
+    module Create
+      extend Ribose::Actions::Base
+
+      def create
+        create_resource[resource]
+      end
+
+      private
+
+      # Resource key
+      def resource; end
+
+      # Attribute validations
+      #
+      # This method will be invoked by the create action to validate the
+      # attributes before submitting to the actual endpoint. We can override
+      # this one to validate user provider attributes.
+      #
+      def validate(attributes)
+        attributes
+      end
+
+      def request_body(attributes)
+        { resource.to_sym => validate(attributes) }
+      end
+
+      def create_resource
+        Ribose::Request.post(resources, request_body(attributes))
+      end
+
+      module ClassMethods
+        # Create resource
+        #
+        # @param attributes [Hash] Resoruce attributes
+        # @return [Sawyer::Resource] Newly created resource
+        #
+        def create(attributes)
+          new(attributes).create
+        end
+      end
+    end
+  end
+end

--- a/lib/ribose/conversation.rb
+++ b/lib/ribose/conversation.rb
@@ -1,10 +1,7 @@
 module Ribose
   class Conversation < Ribose::Base
     include Ribose::Actions::All
-
-    def create
-      create_conversation[:conversation]
-    end
+    include Ribose::Actions::Create
 
     def remove
       Ribose::Request.delete([resources, conversation_id].join("/"))
@@ -43,14 +40,16 @@ module Ribose
       @conversation_id = attributes.delete(:conversation_id)
     end
 
+    def resource
+      "conversation"
+    end
+
     def resources
       ["spaces", space_id, "conversation", "conversations"].join("/")
     end
 
-    def create_conversation
-      Ribose::Request.post(
-        resources, conversation: attributes.merge(space_id: space_id)
-      )
+    def validate(attributes)
+      attributes.merge(space_id: space_id)
     end
   end
 end

--- a/lib/ribose/space.rb
+++ b/lib/ribose/space.rb
@@ -4,13 +4,10 @@ module Ribose
   class Space < Ribose::Base
     include Ribose::Actions::All
     include Ribose::Actions::Fetch
-
-    def create
-      create_space[:space]
-    end
+    include Ribose::Actions::Create
 
     def self.create(name:, **attributes)
-      new(space: attributes.merge(name: name)).create
+      new(attributes.merge(name: name)).create
     end
 
     def self.remove(space_uuid, options = {})
@@ -21,12 +18,12 @@ module Ribose
 
     attr_reader :space
 
-    def resources
-      "spaces"
+    def resource
+      "space"
     end
 
-    def create_space
-      Ribose::Request.post(resources, space: space)
+    def resources
+      "spaces"
     end
 
     def extract_local_attributes

--- a/spec/ribose/actions/create_spec.rb
+++ b/spec/ribose/actions/create_spec.rb
@@ -1,0 +1,40 @@
+require "spec_helper"
+require "ribose/actions/create"
+
+RSpec.describe "TestCreateAction" do
+  describe ".create" do
+    it "creates a new resource with provided details" do
+      stub_ribose_space_create_api(space_attributes)
+      space = Ribose::TestCreateAction.create(space_attributes)
+
+      expect(space.id).not_to be_nil
+      expect(space.name).to eq("Trip to the Mars")
+      expect(space.visibility).to eq("invisible")
+    end
+  end
+
+  def space_attributes
+    {
+      access: "private",
+      space_category_id: 12,
+      description: "The long awaited dream!",
+      name: "Trip to the Mars",
+    }
+  end
+
+  module Ribose
+    class TestCreateAction < Ribose::Base
+      include Ribose::Actions::Create
+
+      private
+
+      def resource
+        "space"
+      end
+
+      def resources
+        [resource, "s"].join
+      end
+    end
+  end
+end


### PR DESCRIPTION
Pretty much most of our resource creation is duplicating the same behavior, in a high-level, the main differences are in attributes & we should be able to share the remaining between other resources

This commit extracts the `create` action to a separate module and it also adds a couple of hook method to provide a resource specific validations. This commit also removes all of the existing create related duplications.