### PR TITLE
Retrieve the list of connection invitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,14 @@ interface and it will retrieve the suggested users.
 Ribose::Connection.suggestions
 ```
 
+### Invitations
+
+#### List connection invitations
+
+```ruby
+Ribose::ConnectionInvitation.all
+```
+
 ### Calendar
 
 #### List user calendars

--- a/lib/ribose.rb
+++ b/lib/ribose.rb
@@ -16,6 +16,7 @@ require "ribose/member"
 require "ribose/space_file"
 require "ribose/conversation"
 require "ribose/message"
+require "ribose/connection_invitation"
 
 module Ribose
   def self.root

--- a/lib/ribose/connection_invitation.rb
+++ b/lib/ribose/connection_invitation.rb
@@ -1,0 +1,15 @@
+module Ribose
+  class ConnectionInvitation < Ribose::Base
+    include Ribose::Actions::All
+
+    private
+
+    def resources_key
+      "to_connections"
+    end
+
+    def resources
+      "invitations/to_connection"
+    end
+  end
+end

--- a/spec/fixtures/connection_invitations.json
+++ b/spec/fixtures/connection_invitations.json
@@ -1,0 +1,28 @@
+{
+  "to_connections": [
+    {
+      "id": 27742,
+      "email": "john.doe@example.com",
+      "body": "Hello,\n\nI'd like to invite you to collaborate with me on Ribose, a cloud collaboration platform that makes working together easy and fun.\n\nSimply accept this invitation to continue. Thanks!\n",
+      "created_at": "2017-09-19T08:18:16.000+00:00",
+      "state": 0,
+      "type": "Invitation::ToConnection",
+      "updated_at": "2017-09-19T08:18:16.000+00:00",
+      "invitee": {
+        "id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+        "connected": true,
+        "name": "John Doe",
+        "mutual_spaces": [
+          "268b0407-c3a3-4aad-8693-fdba789f7f0d",
+          "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc"
+        ]
+      },
+      "inviter": {
+        "id": "2970d105-5ccc-4a8c-b0c4-ec32d539a00a",
+        "connected": false,
+        "name": "Jennie Doe",
+        "mutual_spaces": []
+      }
+    }
+  ]
+}

--- a/spec/ribose/connection_invitation_spec.rb
+++ b/spec/ribose/connection_invitation_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+
+RSpec.describe Ribose::ConnectionInvitation do
+  describe ".all" do
+    it "retrieves all of the connection invitations" do
+      stub_ribose_connection_invitation_lis_api
+      invitations = Ribose::ConnectionInvitation.all
+
+      expect(invitations.count).to eq(1)
+      expect(invitations.first.inviter.name).to eq("Jennie Doe")
+      expect(invitations.first.email).to eq("john.doe@example.com")
+    end
+  end
+end

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -126,6 +126,12 @@ module Ribose
       )
     end
 
+    def stub_ribose_connection_invitation_lis_api
+      stub_api_response(
+        :get, "invitations/to_connection", filename: "connection_invitations"
+      )
+    end
+
     private
 
     def ribose_endpoint(endpoint)


### PR DESCRIPTION
Ribose user invite another user to stay connected, and Ribose API also exposes an endpoint to retrieve those invitations. This commit utilize that endpoint and provide a ruby binding to retrieve all of the pending connection invitations.

```ruby
Ribose::ConnectionInvitation.all
```