### PR TITLE
Interface to retrieve space invitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,12 @@ Ribose::Connection.suggestions
 Ribose::ConnectionInvitation.all
 ```
 
+#### List space invitations
+
+```ruby
+Ribose::SpaceInvitation.all
+```
+
 ### Calendar
 
 #### List user calendars

--- a/lib/ribose.rb
+++ b/lib/ribose.rb
@@ -16,6 +16,7 @@ require "ribose/member"
 require "ribose/space_file"
 require "ribose/conversation"
 require "ribose/message"
+require "ribose/space_invitation"
 require "ribose/connection_invitation"
 
 module Ribose

--- a/lib/ribose/space_invitation.rb
+++ b/lib/ribose/space_invitation.rb
@@ -1,0 +1,15 @@
+module Ribose
+  class SpaceInvitation < Ribose::Base
+    include Ribose::Actions::All
+
+    private
+
+    def resources_key
+      "to_spaces"
+    end
+
+    def resources
+      "invitations/to_space"
+    end
+  end
+end

--- a/spec/fixtures/space_invitations.json
+++ b/spec/fixtures/space_invitations.json
@@ -1,0 +1,34 @@
+{
+  "to_spaces": [
+    {
+      "id": 27743,
+      "email": null,
+      "body": "John Doe invites you to join `The CLI Space'.  Join now!",
+      "created_at": "2017-09-19T09:32:53.000+00:00",
+      "state": 0,
+      "role_id": 41739,
+      "type": "Invitation::ToSpace",
+      "updated_at": "2017-09-19T09:32:53.000+00:00",
+      "inviter": {
+        "id": "2970d105-5ccc-4a8c-b0c4-ec32d539a00a",
+        "connected": true,
+        "name": "Jennie Doe",
+        "mutual_spaces": []
+      },
+      "space": {
+        "id": "52e47e18-9a9d-4663-94c5-abcb18fa783a",
+        "name": "The CLI Space",
+        "members_count": 1
+      },
+      "invitee": {
+        "id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+        "connected": true,
+        "name": "Jennie Doe",
+        "mutual_spaces": [
+          "268b0407-c3a3-4aad-8693-fdba789f7f0d",
+          "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc"
+        ]
+      }
+    }
+  ]
+}

--- a/spec/ribose/space_invitation_spec.rb
+++ b/spec/ribose/space_invitation_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+
+RSpec.describe Ribose::SpaceInvitation do
+  describe ".all" do
+    it "retrieves the list of space invitations" do
+      stub_ribose_space_invitation_lis_api
+      invitations = Ribose::SpaceInvitation.all
+
+      expect(invitations.count).to eq(1)
+      expect(invitations.first.type).to eq("Invitation::ToSpace")
+      expect(invitations.first.space.name).to eq("The CLI Space")
+    end
+  end
+end

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -132,6 +132,12 @@ module Ribose
       )
     end
 
+    def stub_ribose_space_invitation_lis_api
+      stub_api_response(
+        :get, "invitations/to_space", filename: "space_invitations"
+      )
+    end
+
     private
 
     def ribose_endpoint(endpoint)


### PR DESCRIPTION
This commit utilize the Ribose Space Invitation API and provide an ruby binding to retrieve all of the pending space invitations Usages:

```ruby
Ribose::SpaceInvitation.all
```