### PR TITLE
Add interface to invite a user to a space

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,18 @@ Ribose::ConnectionInvitation.all
 Ribose::SpaceInvitation.all
 ```
 
+#### Invite user to a space
+
+```ruby
+Ribose::SpaceInvitation.create(
+  state: "0",
+  space_id: "123_456_789",
+  invitee_id: "456_789_012",
+  type: "Invitation::ToSpace",
+  body: "Please join to this amazing space",
+)
+```
+
 ### Calendar
 
 #### List user calendars

--- a/lib/ribose/actions/create.rb
+++ b/lib/ribose/actions/create.rb
@@ -6,13 +6,28 @@ module Ribose
       extend Ribose::Actions::Base
 
       def create
-        create_resource[resource]
+        create_resource[resource_key]
       end
 
       private
 
-      # Resource key
+      # Resource
+      #
+      # This method should return the resource name that should
+      # be used to orgnize the request body for create operation
+      #
       def resource; end
+
+      # Response key
+      #
+      # This method should return the key that is used as a root
+      # elemenet in the response for create operation, ideally it
+      # is same as the `resource` method but some endpoit might
+      # need some variation.
+      #
+      def resource_key
+        resource
+      end
 
       # Attribute validations
       #

--- a/lib/ribose/space_invitation.rb
+++ b/lib/ribose/space_invitation.rb
@@ -1,15 +1,28 @@
 module Ribose
   class SpaceInvitation < Ribose::Base
     include Ribose::Actions::All
+    include Ribose::Actions::Create
 
     private
 
+    def resource
+      "invitation"
+    end
+
+    def resource_key
+      "to_space"
+    end
+
     def resources_key
-      "to_spaces"
+      [resource_key, "s"].join
     end
 
     def resources
       "invitations/to_space"
+    end
+
+    def validate(space_id:, invitee_id:, **attributes)
+      attributes.merge(space_id: space_id, invitee_id: invitee_id)
     end
   end
 end

--- a/spec/fixtures/space_invitation.json
+++ b/spec/fixtures/space_invitation.json
@@ -1,0 +1,32 @@
+{
+  "to_space": {
+    "id": 27747,
+    "email": null,
+    "body": null,
+    "created_at": "2017-09-20T06:42:33.503+00:00",
+    "state": 0,
+    "role_id": 41745,
+    "type": "Invitation::ToSpace",
+    "updated_at": "2017-09-20T06:42:33.637Z",
+    "inviter": {
+      "id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+      "connected": true,
+      "name": "John Doe",
+      "mutual_spaces": [
+        "268b0407-c3a3-4aad-8693-fdba789f7f0d",
+        "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc"
+      ]
+    },
+    "space": {
+      "id": "268b0407-c3a3-4aad-8693-fdba789f7f0d",
+      "name": "Trip to Mars!",
+      "members_count": 1
+    },
+    "invitee": {
+      "id": "2970d105-5ccc-4a8c-b0c4-ec32d539a00a",
+      "connected": true,
+      "name": "Jennie Doe",
+      "mutual_spaces": []
+    }
+  }
+}

--- a/spec/ribose/space_invitation_spec.rb
+++ b/spec/ribose/space_invitation_spec.rb
@@ -11,4 +11,25 @@ RSpec.describe Ribose::SpaceInvitation do
       expect(invitations.first.space.name).to eq("The CLI Space")
     end
   end
+
+  describe ".create" do
+    it "creates an invitation to a specific space" do
+      stub_ribose_space_invitation_create_api(invitation_attributes)
+      invitation = Ribose::SpaceInvitation.create(invitation_attributes)
+
+      expect(invitation.id).not_to be_nil
+      expect(invitation.inviter.name).to eq("John Doe")
+      expect(invitation.type).to eq("Invitation::ToSpace")
+      expect(invitation.space.name).to eq("Trip to Mars!")
+    end
+  end
+
+  def invitation_attributes
+    @invitation ||= {
+      state: "0",
+      body: "Please join!",
+      space_id: "123_456_789",
+      invitee_id: "456_789_012",
+    }
+  end
 end

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -138,6 +138,15 @@ module Ribose
       )
     end
 
+    def stub_ribose_space_invitation_create_api(attributes)
+      stub_api_response(
+        :post,
+        "invitations/to_space",
+        data: { invitation: attributes },
+        filename: "space_invitation",
+      )
+    end
+
     private
 
     def ribose_endpoint(endpoint)


### PR DESCRIPTION
Ribose Space Invitation API offers endpoint to invite user to a user space, and this commit utilize that endpoint and provide an interface to send out that invitation. Usages:

```ruby
Ribose::SpaceInvitation.create(
  state: "0",
  space_id: "123_456_789",
  invitee_id: "456_789_012",
  type: "Invitation::ToSpace",
  body: "Please join to this amazing space",
)
```