### PR TITLE
Interface to fetch connection invitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,12 @@ Ribose::ConnectionInvitation.all
 Ribose::SpaceInvitation.all
 ```
 
+#### Fetch a connection invitation
+
+```ruby
+Ribose::ConnectionInvitation.fetch(invitation_id)
+```
+
 #### Invite user to a space
 
 ```ruby

--- a/lib/ribose/connection_invitation.rb
+++ b/lib/ribose/connection_invitation.rb
@@ -1,11 +1,16 @@
 module Ribose
   class ConnectionInvitation < Ribose::Base
     include Ribose::Actions::All
+    include Ribose::Actions::Fetch
 
     private
 
+    def resource_key
+      "to_connection"
+    end
+
     def resources_key
-      "to_connections"
+      [resource_key, "s"].join
     end
 
     def resources

--- a/spec/fixtures/connection_invitation.json
+++ b/spec/fixtures/connection_invitation.json
@@ -1,0 +1,26 @@
+{
+  "to_connection": {
+    "id": 27748,
+    "email": "jennie.doe@example.com",
+    "body": "Hello,\n\nI'd like to invite you to collaborate with me on Ribose, a cloud collaboration platform that makes working together easy and fun.\n\nSimply accept this invitation to continue. Thanks!\n",
+    "created_at": "2017-09-20T08:22:55.000+00:00",
+    "state": 0,
+    "type": "Invitation::ToConnection",
+    "updated_at": "2017-09-20T08:22:55.000+00:00",
+    "invitee": {
+      "id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+      "connected": true,
+      "name": "John Doe",
+      "mutual_spaces": [
+        "268b0407-c3a3-4aad-8693-fdba789f7f0d",
+        "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc"
+      ]
+    },
+    "inviter": {
+      "id": "2970d105-5ccc-4a8c-b0c4-ec32d539a00a",
+      "connected": false,
+      "name": "Jennie Doe",
+      "mutual_spaces": []
+    }
+  }
+}

--- a/spec/ribose/connection_invitation_spec.rb
+++ b/spec/ribose/connection_invitation_spec.rb
@@ -11,4 +11,17 @@ RSpec.describe Ribose::ConnectionInvitation do
       expect(invitations.first.email).to eq("john.doe@example.com")
     end
   end
+
+  describe ".fetch" do
+    it "retrieves the details of an invitation" do
+      invitation_id = 123_456_789
+      stub_ribose_connection_invitation_fetch_api(invitation_id)
+      invitation = Ribose::ConnectionInvitation.fetch(invitation_id)
+
+      expect(invitation.id).not_to be_nil
+      expect(invitation.inviter.name).to eq("Jennie Doe")
+      expect(invitation.email).to eq("jennie.doe@example.com")
+      expect(invitation.type).to eq("Invitation::ToConnection")
+    end
+  end
 end

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -132,6 +132,14 @@ module Ribose
       )
     end
 
+    def stub_ribose_connection_invitation_fetch_api(invitation_id)
+      stub_api_response(
+        :get,
+        "invitations/to_connection/#{invitation_id}",
+        filename: "connection_invitation",
+      )
+    end
+
     def stub_ribose_space_invitation_lis_api
       stub_api_response(
         :get, "invitations/to_space", filename: "space_invitations"


### PR DESCRIPTION
This commit utilize the Connection Invitation API endpoint to retrieve the connection invitation details and provide an ruby binding for this endpoint. Usages:

```ruby
Ribose::ConnectionInvitation.fetch(invitation_id)
```