### PR TITLE
Interface to cancel a connection invitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,12 @@ Ribose::SpaceInvitation.all
 Ribose::ConnectionInvitation.fetch(invitation_id)
 ```
 
+#### Cancel a connection invitation
+
+```ruby
+Ribose::ConnectionInvitation.cancel(invitation_id)
+```
+
 #### Invite user to a space
 
 ```ruby

--- a/lib/ribose/connection_invitation.rb
+++ b/lib/ribose/connection_invitation.rb
@@ -3,6 +3,10 @@ module Ribose
     include Ribose::Actions::All
     include Ribose::Actions::Fetch
 
+    def self.cancel(invitation_id)
+      Ribose::Request.delete("invitations/to_connection/#{invitation_id}")
+    end
+
     private
 
     def resource_key

--- a/spec/ribose/connection_invitation_spec.rb
+++ b/spec/ribose/connection_invitation_spec.rb
@@ -24,4 +24,15 @@ RSpec.describe Ribose::ConnectionInvitation do
       expect(invitation.type).to eq("Invitation::ToConnection")
     end
   end
+
+  describe ".cancel" do
+    it "cancels a pending connection inviation" do
+      invitation_id = 123_456_789
+      stub_ribose_connection_invitation_cancel_api(invitation_id)
+
+      expect do
+        Ribose::ConnectionInvitation.cancel(invitation_id)
+      end.not_to raise_error
+    end
+  end
 end

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -140,6 +140,12 @@ module Ribose
       )
     end
 
+    def stub_ribose_connection_invitation_cancel_api(invitation_id)
+      stub_api_response(
+        :delete, "invitations/to_connection/#{invitation_id}", filename: "empty"
+      )
+    end
+
     def stub_ribose_space_invitation_lis_api
       stub_api_response(
         :get, "invitations/to_space", filename: "space_invitations"


### PR DESCRIPTION
This commit adds an interface to cancel a pending connection invitation request and the usages is pretty simple, all we need to do is invoke the following command

```ruby
Ribose::ConnectionInvitation.cancel(invitation_id)
```