### PR TITLE
Interface to accept connection invitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,12 @@ Ribose::SpaceInvitation.all
 Ribose::ConnectionInvitation.fetch(invitation_id)
 ```
 
+#### Accept a connection invitation
+
+```ruby
+Ribose::ConnectionInvitation.accept(invitation_id)
+```
+
 #### Cancel a connection invitation
 
 ```ruby

--- a/lib/ribose/connection_invitation.rb
+++ b/lib/ribose/connection_invitation.rb
@@ -3,11 +3,21 @@ module Ribose
     include Ribose::Actions::All
     include Ribose::Actions::Fetch
 
+    def accept
+      accept_inviation[resource_key]
+    end
+
+    def self.accept(invitation_id)
+      new(invitation_id: invitation_id).accept
+    end
+
     def self.cancel(invitation_id)
       Ribose::Request.delete("invitations/to_connection/#{invitation_id}")
     end
 
     private
+
+    attr_reader :invitation_id
 
     def resource_key
       "to_connection"
@@ -19,6 +29,16 @@ module Ribose
 
     def resources
       "invitations/to_connection"
+    end
+
+    def extract_local_attributes
+      @invitation_id = attributes.delete(:invitation_id)
+    end
+
+    def accept_inviation
+      Ribose::Request.put(
+        [resources, invitation_id].join("/"), invitation: { state: 1 }
+      )
     end
   end
 end

--- a/spec/fixtures/connection_invitation_accepted.json
+++ b/spec/fixtures/connection_invitation_accepted.json
@@ -1,0 +1,26 @@
+{
+  "to_connection": {
+    "id": 27751,
+    "email": "john.doe@example.com",
+    "body": "Hello,\n\nI'd like to invite you to collaborate with me on Ribose, a cloud collaboration platform that makes working together easy and fun.\n\nSimply accept this invitation to continue. Thanks!\n",
+    "created_at": "2017-09-27T04:42:34.000+00:00",
+    "state": 1,
+    "type": "Invitation::ToConnection",
+    "updated_at": "2017-09-27T04:44:28.000+00:00",
+    "invitee": {
+      "id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+      "connected": true,
+      "name": "John Doe",
+      "mutual_spaces": [
+        "268b0407-c3a3-4aad-8693-fdba789f7f0d",
+        "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc"
+      ]
+    },
+    "inviter": {
+      "id": "2970d105-5ccc-4a8c-b0c4-ec32d539a00a",
+      "connected": true,
+      "name": "Jennie Doe",
+      "mutual_spaces": []
+    }
+  }
+}

--- a/spec/ribose/connection_invitation_spec.rb
+++ b/spec/ribose/connection_invitation_spec.rb
@@ -25,6 +25,19 @@ RSpec.describe Ribose::ConnectionInvitation do
     end
   end
 
+  describe ".accept" do
+    it "accepts a connection inviation" do
+      invitation_id = 123_456_789
+
+      stub_ribose_connection_invitation_accept_api(invitation_id)
+      inviation = Ribose::ConnectionInvitation.accept(invitation_id)
+
+      expect(inviation.state).to eq(1)
+      expect(inviation.id).not_to be_nil
+      expect(inviation.inviter.name).to eq("Jennie Doe")
+    end
+  end
+
   describe ".cancel" do
     it "cancels a pending connection inviation" do
       invitation_id = 123_456_789

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -140,6 +140,15 @@ module Ribose
       )
     end
 
+    def stub_ribose_connection_invitation_accept_api(invitation_id)
+      stub_api_response(
+        :put,
+        "invitations/to_connection/#{invitation_id}",
+        data: { invitation: { state: 1 } },
+        filename: "connection_invitation_accepted",
+      )
+    end
+
     def stub_ribose_connection_invitation_cancel_api(invitation_id)
       stub_api_response(
         :delete, "invitations/to_connection/#{invitation_id}", filename: "empty"


### PR DESCRIPTION
Once a Ribose user received an connection invitation then the Ribose API offers the invitee user to accept or decline the connection request, and this commit use that endpoint and add a new interface to accept a pending connection invitation

```ruby
Ribose::ConnectionInvitation.accept(invitation_id)
```