### PR TITLE
Interface to reject a connection invitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,12 @@ Ribose::ConnectionInvitation.fetch(invitation_id)
 Ribose::ConnectionInvitation.accept(invitation_id)
 ```
 
+#### Reject a connection invitation
+
+```ruby
+Ribose::ConnectionInvitation.reject(invitation_id)
+```
+
 #### Cancel a connection invitation
 
 ```ruby

--- a/lib/ribose/connection_invitation.rb
+++ b/lib/ribose/connection_invitation.rb
@@ -3,12 +3,16 @@ module Ribose
     include Ribose::Actions::All
     include Ribose::Actions::Fetch
 
-    def accept
-      accept_inviation[resource_key]
+    def update
+      update_invitation[resource_key]
     end
 
     def self.accept(invitation_id)
-      new(invitation_id: invitation_id).accept
+      new(invitation_id: invitation_id, state: 1).update
+    end
+
+    def self.reject(invitation_id)
+      new(invitation_id: invitation_id, state: 2).update
     end
 
     def self.cancel(invitation_id)
@@ -35,9 +39,10 @@ module Ribose
       @invitation_id = attributes.delete(:invitation_id)
     end
 
-    def accept_inviation
+    def update_invitation
       Ribose::Request.put(
-        [resources, invitation_id].join("/"), invitation: { state: 1 }
+        [resources, invitation_id].join("/"),
+        invitation: { state: attributes[:state] },
       )
     end
   end

--- a/spec/ribose/connection_invitation_spec.rb
+++ b/spec/ribose/connection_invitation_spec.rb
@@ -26,15 +26,28 @@ RSpec.describe Ribose::ConnectionInvitation do
   end
 
   describe ".accept" do
-    it "accepts a connection inviation" do
+    it "accepts a connection invitation" do
       invitation_id = 123_456_789
 
-      stub_ribose_connection_invitation_accept_api(invitation_id)
-      inviation = Ribose::ConnectionInvitation.accept(invitation_id)
+      stub_ribose_connection_invitation_update_api(invitation_id, 1)
+      invitation = Ribose::ConnectionInvitation.accept(invitation_id)
 
-      expect(inviation.state).to eq(1)
-      expect(inviation.id).not_to be_nil
-      expect(inviation.inviter.name).to eq("Jennie Doe")
+      expect(invitation.state).to eq(1)
+      expect(invitation.id).not_to be_nil
+      expect(invitation.inviter.name).to eq("Jennie Doe")
+    end
+  end
+
+  describe ".reject" do
+    it "rejects a connection invitation" do
+      invitation_id = 123_456_789
+
+      stub_ribose_connection_invitation_update_api(invitation_id, 2)
+      invitation = Ribose::ConnectionInvitation.reject(invitation_id)
+
+      expect(invitation.id).not_to be_nil
+      expect(invitation.state).not_to be_nil
+      expect(invitation.inviter.name).to eq("Jennie Doe")
     end
   end
 

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -140,11 +140,11 @@ module Ribose
       )
     end
 
-    def stub_ribose_connection_invitation_accept_api(invitation_id)
+    def stub_ribose_connection_invitation_update_api(invitation_id, state)
       stub_api_response(
         :put,
         "invitations/to_connection/#{invitation_id}",
-        data: { invitation: { state: 1 } },
+        data: { invitation: { state: state } },
         filename: "connection_invitation_accepted",
       )
     end


### PR DESCRIPTION
In the previous commit we have added the interface to accept a connection invitation through the API, but user might also want to reject a connection request & that's where this interface fit

```ruby
Ribose::ConnectionInvitation.reject(invitation_id)
```