### PR TITLE
Interface to create connection invitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,15 @@ Ribose::SpaceInvitation.all
 Ribose::ConnectionInvitation.fetch(invitation_id)
 ```
 
+#### Create mass connection invitations
+
+```ruby
+Ribose::ConnectionInvitation.create(
+  emails: ["email-one@example.com", "email-two@example.com"],
+  body: "This contains the details message about the invitation",
+)
+```
+
 #### Accept a connection invitation
 
 ```ruby

--- a/lib/ribose/connection_invitation.rb
+++ b/lib/ribose/connection_invitation.rb
@@ -7,6 +7,14 @@ module Ribose
       update_invitation[resource_key]
     end
 
+    def create
+      create_invitations[:invitations]
+    end
+
+    def self.create(body:, emails:)
+      new(body: body, emails: emails).create
+    end
+
     def self.accept(invitation_id)
       new(invitation_id: invitation_id, state: 1).update
     end
@@ -23,6 +31,10 @@ module Ribose
 
     attr_reader :invitation_id
 
+    def resource
+      "invitation"
+    end
+
     def resource_key
       "to_connection"
     end
@@ -37,6 +49,13 @@ module Ribose
 
     def extract_local_attributes
       @invitation_id = attributes.delete(:invitation_id)
+    end
+
+    def create_invitations
+      Ribose::Request.post(
+        [resources, "mass_create"].join("/"),
+        invitation: { body: attributes[:body], emails: attributes[:emails] },
+      )
     end
 
     def update_invitation

--- a/spec/fixtures/connection_invitations_created.json
+++ b/spec/fixtures/connection_invitations_created.json
@@ -1,0 +1,37 @@
+{
+  "invitations": {
+    "success": {
+      "emails": {
+        "jennie.doe@example.com": {
+          "id": 27756,
+          "email": "jennie.doe@example.com",
+          "body": "Hi, Let's get connected in Ribose",
+          "created_at": "2017-09-27T07:54:01.305+00:00",
+          "state": 0,
+          "type": "Invitation::ToConnection",
+          "updated_at": "2017-09-27T07:54:01.416Z",
+          "invitee": {
+            "id": "2970d105-5ccc-4a8c-b0c4-ec32d539a00a",
+            "connected": false,
+            "name": "Jennie Doe",
+            "mutual_spaces": []
+          },
+          "inviter": {
+            "id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+            "connected": true,
+            "name": "John Doe",
+            "mutual_spaces": [
+              "268b0407-c3a3-4aad-8693-fdba789f7f0d",
+              "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc"
+            ]
+          }
+        }
+      },
+      "user_ids": {}
+    },
+    "errors": {
+      "emails": {},
+      "user_ids": {}
+    }
+  }
+}

--- a/spec/ribose/connection_invitation_spec.rb
+++ b/spec/ribose/connection_invitation_spec.rb
@@ -25,6 +25,21 @@ RSpec.describe Ribose::ConnectionInvitation do
     end
   end
 
+  describe ".create" do
+    it "creates new connection invitations" do
+      emails = ["jennie.doe@example.com"]
+      message_body = "Hi, Let's get connected in Ribose"
+
+      stub_ribose_connection_invitation_create_api(emails, message_body)
+      invitations = Ribose::ConnectionInvitation.create(
+        emails: emails, body: message_body,
+      )
+
+      expect(invitations.success.emails.first[0].to_s).to eq(emails.first)
+      expect(invitations.success.emails[emails.first].body).to eq(message_body)
+    end
+  end
+
   describe ".accept" do
     it "accepts a connection invitation" do
       invitation_id = 123_456_789

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -140,6 +140,15 @@ module Ribose
       )
     end
 
+    def stub_ribose_connection_invitation_create_api(emails, body)
+      stub_api_response(
+        :post,
+        "invitations/to_connection/mass_create",
+        filename: "connection_invitations_created",
+        data: { invitation: { body: body, emails: emails } },
+      )
+    end
+
     def stub_ribose_connection_invitation_update_api(invitation_id, state)
       stub_api_response(
         :put,


### PR DESCRIPTION
This commit adds an interface to create connection invitation using this Ruby client. This interface expect `emails` and the `body` as an arguments and it will send out the invitation to that email.

One another interesting thing, the `emails` key also accepts an array of emails and if we provide multiple emails with it then it will create some mass invitations.

```ruby
Ribose::ConnectionInvitation.create(
  emails: ["email-one@example.com", "email-two@example.com"],
  body: "This contains the details message about the invitation",
)
```