### PR TITLE
Interface to cancel a space invitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,12 @@ Ribose::SpaceInvitation.create(
 )
 ```
 
+#### Cancel a space invitation
+
+```ruby
+Ribose::SpaceInvitation.cancel(invitation_id)
+```
+
 ### Calendar
 
 #### List user calendars

--- a/lib/ribose/space_invitation.rb
+++ b/lib/ribose/space_invitation.rb
@@ -3,6 +3,10 @@ module Ribose
     include Ribose::Actions::All
     include Ribose::Actions::Create
 
+    def self.cancel(invitation_id)
+      Ribose::Request.delete(["invitations/to_space", invitation_id].join("/"))
+    end
+
     private
 
     def resource

--- a/spec/ribose/space_invitation_spec.rb
+++ b/spec/ribose/space_invitation_spec.rb
@@ -24,6 +24,17 @@ RSpec.describe Ribose::SpaceInvitation do
     end
   end
 
+  describe ".cancel" do
+    it "cancels a space invitation" do
+      invitation_id = 123_456_789
+      stub_ribose_space_invitation_cancel_api(invitation_id)
+
+      expect do
+        Ribose::SpaceInvitation.cancel(invitation_id)
+      end.not_to raise_error
+    end
+  end
+
   def invitation_attributes
     @invitation ||= {
       state: "0",

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -179,6 +179,12 @@ module Ribose
       )
     end
 
+    def stub_ribose_space_invitation_cancel_api(invitation_id)
+      stub_api_response(
+        :delete, "invitations/to_space/#{invitation_id}", filename: "empty"
+      )
+    end
+
     private
 
     def ribose_endpoint(endpoint)


### PR DESCRIPTION
Ribose API offers endpoint to invite other user to a user space, but sometime we might sent some wrong invitation or we might not have want to send invitation to some user and what's there this interface comes it, it provides an easier interface to cancel any of the un-intended invitation.

```ruby
Ribose::SpaceInvitation.cancel(invitation_id)
```