### PR TITLE
Interface to accept space invitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,12 @@ Ribose::SpaceInvitation.create(
 )
 ```
 
+#### Accept a space invitation
+
+```ruby
+Ribose::SpaceInvitation.accept(invitation_id)
+```
+
 #### Cancel a space invitation
 
 ```ruby

--- a/lib/ribose/space_invitation.rb
+++ b/lib/ribose/space_invitation.rb
@@ -3,11 +3,21 @@ module Ribose
     include Ribose::Actions::All
     include Ribose::Actions::Create
 
+    def update
+      update_invitation[resource_key]
+    end
+
+    def self.accept(invitation_id)
+      new(invitation_id: invitation_id, state: 1).update
+    end
+
     def self.cancel(invitation_id)
       Ribose::Request.delete(["invitations/to_space", invitation_id].join("/"))
     end
 
     private
+
+    attr_reader :invitation_id
 
     def resource
       "invitation"
@@ -25,8 +35,19 @@ module Ribose
       "invitations/to_space"
     end
 
+    def extract_local_attributes
+      @invitation_id = attributes.delete(:invitation_id)
+    end
+
     def validate(space_id:, invitee_id:, **attributes)
       attributes.merge(space_id: space_id, invitee_id: invitee_id)
+    end
+
+    def update_invitation
+      Ribose::Request.put(
+        [resources, invitation_id].join("/"),
+        invitation: { state: attributes[:state] },
+      )
     end
   end
 end

--- a/spec/fixtures/space_invitation_updated.json
+++ b/spec/fixtures/space_invitation_updated.json
@@ -1,0 +1,35 @@
+{
+  "to_space": {
+    "id": 27743,
+    "email": null,
+    "body": "Jennie Doe invites you to join `The CLI Space'.  Join now to start collaborating!",
+    "created_at": "2017-09-19T09:32:53.000+00:00",
+    "state": 1,
+    "role_id": 41739,
+    "type": "Invitation::ToSpace",
+    "updated_at": "2017-09-28T04:29:47.000+00:00",
+    "inviter": {
+      "id": "2970d105-5ccc-4a8c-b0c4-ec32d539a00a",
+      "connected": false,
+      "name": "Jennie Doe",
+      "mutual_spaces": [
+        "52e47e18-9a9d-4663-94c5-abcb18fa783a"
+      ]
+    },
+    "space": {
+      "id": "52e47e18-9a9d-4663-94c5-abcb18fa783a",
+      "name": "The CLI Space",
+      "members_count": 2
+    },
+    "invitee": {
+      "id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+      "connected": true,
+      "name": "John Doe",
+      "mutual_spaces": [
+        "268b0407-c3a3-4aad-8693-fdba789f7f0d",
+        "52e47e18-9a9d-4663-94c5-abcb18fa783a",
+        "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc"
+      ]
+    }
+  }
+}

--- a/spec/ribose/space_invitation_spec.rb
+++ b/spec/ribose/space_invitation_spec.rb
@@ -24,6 +24,19 @@ RSpec.describe Ribose::SpaceInvitation do
     end
   end
 
+  describe ".accept" do
+    it "accepts a space invitation" do
+      invitation_id = 123_456_789
+
+      stub_ribose_space_invitation_update_api(invitation_id, 1)
+      invitation = Ribose::SpaceInvitation.accept(invitation_id)
+
+      expect(invitation.state).to eq(1)
+      expect(invitation.id).not_to be_nil
+      expect(invitation.type).to eq("Invitation::ToSpace")
+    end
+  end
+
   describe ".cancel" do
     it "cancels a space invitation" do
       invitation_id = 123_456_789

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -179,6 +179,15 @@ module Ribose
       )
     end
 
+    def stub_ribose_space_invitation_update_api(invitation_id, state)
+      stub_api_response(
+        :put,
+        "invitations/to_space/#{invitation_id}",
+        data: { invitation: { state: state } },
+        filename: "space_invitation_updated",
+      )
+    end
+
     def stub_ribose_space_invitation_cancel_api(invitation_id)
       stub_api_response(
         :delete, "invitations/to_space/#{invitation_id}", filename: "empty"


### PR DESCRIPTION
Once one user invite another invitee to join a space then the invitee can accept/reject a space invitation, and this commit adds the interface to accept the invitation, so if the invitee decides to join the space then he can use this one.

```ruby
Ribose::SpaceInvitation.accept(invitation_id)
```