### PR TITLE
Interface to reject a space invitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,12 @@ Ribose::SpaceInvitation.create(
 Ribose::SpaceInvitation.accept(invitation_id)
 ```
 
+#### Reject a space invitation
+
+```ruby
+Ribose::SpaceInvitation.reject(invitation_id)
+```
+
 #### Cancel a space invitation
 
 ```ruby

--- a/lib/ribose/space_invitation.rb
+++ b/lib/ribose/space_invitation.rb
@@ -11,6 +11,10 @@ module Ribose
       new(invitation_id: invitation_id, state: 1).update
     end
 
+    def self.reject(invitation_id)
+      new(invitation_id: invitation_id, state: 2).update
+    end
+
     def self.cancel(invitation_id)
       Ribose::Request.delete(["invitations/to_space", invitation_id].join("/"))
     end

--- a/spec/ribose/space_invitation_spec.rb
+++ b/spec/ribose/space_invitation_spec.rb
@@ -37,6 +37,19 @@ RSpec.describe Ribose::SpaceInvitation do
     end
   end
 
+  describe ".reject" do
+    it "rejects a space invitation" do
+      invitation_id = 123_456_789
+
+      stub_ribose_space_invitation_update_api(invitation_id, 2)
+      invitation = Ribose::SpaceInvitation.reject(invitation_id)
+
+      expect(invitation.id).not_to be_nil
+      expect(invitation.state).not_to be_nil
+      expect(invitation.type).to eq("Invitation::ToSpace")
+    end
+  end
+
   describe ".cancel" do
     it "cancels a space invitation" do
       invitation_id = 123_456_789


### PR DESCRIPTION
Once one user invite another invitee to join a space then the invitee can accept/reject a space invitation, and this commit adds the interface to reject the invitation, so if the invitee decides not to join the space then he can use this one.

```ruby
Ribose::SpaceInvitation.reject(invitation_id)
```