### PR TITLE
Interface to resend a space invitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,12 @@ Ribose::SpaceInvitation.create(
 Ribose::SpaceInvitation.accept(invitation_id)
 ```
 
+#### Resend a space invitation
+
+```ruby
+Ribose::SpaceInvitation.resend(invitation_id)
+```
+
 #### Reject a space invitation
 
 ```ruby

--- a/lib/ribose/space_invitation.rb
+++ b/lib/ribose/space_invitation.rb
@@ -11,6 +11,12 @@ module Ribose
       new(invitation_id: invitation_id, state: 1).update
     end
 
+    def self.resend(invitation_id)
+      Ribose::Request.post(
+        "/invitations/to_new_member/#{invitation_id}/resend", {}
+      )
+    end
+
     def self.reject(invitation_id)
       new(invitation_id: invitation_id, state: 2).update
     end

--- a/spec/ribose/space_invitation_spec.rb
+++ b/spec/ribose/space_invitation_spec.rb
@@ -37,6 +37,18 @@ RSpec.describe Ribose::SpaceInvitation do
     end
   end
 
+  describe ".resend" do
+    it "resends a space invitation to non-member email" do
+      invitation_id = 123_456_789
+
+      stub_ribose_space_invitation_resend_api(invitation_id)
+      invitation = Ribose::SpaceInvitation.resend(invitation_id)
+
+      expect(invitation.to_space).not_to be_nil
+      expect(invitation.to_space.id).not_to be_nil
+    end
+  end
+
   describe ".reject" do
     it "rejects a space invitation" do
       invitation_id = 123_456_789

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -179,6 +179,14 @@ module Ribose
       )
     end
 
+    def stub_ribose_space_invitation_resend_api(invitation_id)
+      stub_api_response(
+        :post,
+        "invitations/to_new_member/#{invitation_id}/resend",
+        filename: "space_invitation_updated",
+      )
+    end
+
     def stub_ribose_space_invitation_update_api(invitation_id, state)
       stub_api_response(
         :put,


### PR DESCRIPTION
Ribose Space Invitation API allow us to invite non-member user to a space, but if for some reason we need it resend invitation to the user then it also offers an endpoint. This commit usages that endpoint and provides an interface for that.

```ruby
Ribose::SpaceInvitation.resend(invitation_id)
```