### PR TITLE
Interface to update a space invitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,12 @@ Ribose::SpaceInvitation.create(
 )
 ```
 
+#### Update a space invitation
+
+```ruby
+Ribose::SpaceInvitation.update(invitation_id, new_attributes_hash)
+```
+
 #### Accept a space invitation
 
 ```ruby

--- a/lib/ribose/space_invitation.rb
+++ b/lib/ribose/space_invitation.rb
@@ -7,6 +7,10 @@ module Ribose
       update_invitation[resource_key]
     end
 
+    def self.update(invitation_id, attributes)
+      new(attributes.merge(invitation_id: invitation_id)).update
+    end
+
     def self.accept(invitation_id)
       new(invitation_id: invitation_id, state: 1).update
     end
@@ -55,8 +59,7 @@ module Ribose
 
     def update_invitation
       Ribose::Request.put(
-        [resources, invitation_id].join("/"),
-        invitation: { state: attributes[:state] },
+        [resources, invitation_id].join("/"), invitation: attributes
       )
     end
   end

--- a/spec/ribose/space_invitation_spec.rb
+++ b/spec/ribose/space_invitation_spec.rb
@@ -24,11 +24,25 @@ RSpec.describe Ribose::SpaceInvitation do
     end
   end
 
+  describe ".update" do
+    it "updates a space invitation" do
+      invitation_id = 123_456_789
+      attributes = { role_id: 123 }
+
+      stub_ribose_space_invitation_update_api(invitation_id, attributes)
+      invitation = Ribose::SpaceInvitation.update(invitation_id, attributes)
+
+      expect(invitation.id).not_to be_nil
+      expect(invitation.role_id).not_to be_nil
+      expect(invitation.type).to eq("Invitation::ToSpace")
+    end
+  end
+
   describe ".accept" do
     it "accepts a space invitation" do
       invitation_id = 123_456_789
+      stub_ribose_space_invitation_update_api(invitation_id, state: 1)
 
-      stub_ribose_space_invitation_update_api(invitation_id, 1)
       invitation = Ribose::SpaceInvitation.accept(invitation_id)
 
       expect(invitation.state).to eq(1)
@@ -52,8 +66,8 @@ RSpec.describe Ribose::SpaceInvitation do
   describe ".reject" do
     it "rejects a space invitation" do
       invitation_id = 123_456_789
+      stub_ribose_space_invitation_update_api(invitation_id, state: 2)
 
-      stub_ribose_space_invitation_update_api(invitation_id, 2)
       invitation = Ribose::SpaceInvitation.reject(invitation_id)
 
       expect(invitation.id).not_to be_nil

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -187,11 +187,11 @@ module Ribose
       )
     end
 
-    def stub_ribose_space_invitation_update_api(invitation_id, state)
+    def stub_ribose_space_invitation_update_api(invitation_id, attributes)
       stub_api_response(
         :put,
         "invitations/to_space/#{invitation_id}",
-        data: { invitation: { state: state } },
+        data: { invitation: attributes },
         filename: "space_invitation_updated",
       )
     end


### PR DESCRIPTION
Ribose Space Invitation API allows us to update an existing space invitation and this commit adds an interface to make it pretty simple, for now we'll use this interface to update user role, but this will work fine with any other valid attributes

```ruby
Ribose::SpaceInvitation.update(
  invitation_id, role_id: 123_456_789,
)
```