### PR TITLE
Interface to send mass space invitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,17 @@ Ribose::SpaceInvitation.create(
 )
 ```
 
+#### Create space invitation - Mass
+
+```ruby
+Ribose::SpaceInvitation.mass_create(
+  space_id,
+  emails: ["email-one@example.com"],
+  role_ids: ["role-for-email-address-in-sequance"],
+  body: "The complete message body for the invitation",
+)
+```
+
 #### Update a space invitation
 
 ```ruby

--- a/lib/ribose/space_invitation.rb
+++ b/lib/ribose/space_invitation.rb
@@ -7,6 +7,14 @@ module Ribose
       update_invitation[resource_key]
     end
 
+    def mass_create
+      create_invitations[:invitations]
+    end
+
+    def self.mass_create(space_id, attributes)
+      new(attributes.merge(space_id: space_id)).mass_create
+    end
+
     def self.update(invitation_id, attributes)
       new(attributes.merge(invitation_id: invitation_id)).update
     end
@@ -57,10 +65,18 @@ module Ribose
       attributes.merge(space_id: space_id, invitee_id: invitee_id)
     end
 
+    def create_invitations
+      Ribose::Request.post(mass_create_path, invitation: attributes)
+    end
+
     def update_invitation
       Ribose::Request.put(
         [resources, invitation_id].join("/"), invitation: attributes
       )
+    end
+
+    def mass_create_path
+      "/spaces/#{attributes[:space_id]}/invitations/to_space/mass_create"
     end
   end
 end

--- a/spec/fixtures/space_mass_invitations.json
+++ b/spec/fixtures/space_mass_invitations.json
@@ -1,0 +1,46 @@
+{
+  "invitations": {
+    "success": {
+      "emails": {
+        "jennie.doe@example.com": {
+          "id": 27764,
+          "email": "jennie.doe@example.com",
+          "body": null,
+          "created_at": "2017-09-29T07:10:08.575+00:00",
+          "state": 0,
+          "role_id": 41745,
+          "type": "Invitation::ToSpace",
+          "updated_at": "2017-09-29T07:10:08.679+00:00",
+          "inviter": {
+            "id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+            "connected": true,
+            "name": "John Doe",
+            "mutual_spaces": [
+              "268b0407-c3a3-4aad-8693-fdba789f7f0d",
+              "52e47e18-9a9d-4663-94c5-abcb18fa783a",
+              "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc"
+            ]
+          },
+          "space": {
+            "id": "268b0407-c3a3-4aad-8693-fdba789f7f0d",
+            "name": "Sample Space",
+            "members_count": 1
+          },
+          "invitee": {
+            "id": "2970d105-5ccc-4a8c-b0c4-ec32d539a00a",
+            "connected": false,
+            "name": "Jennie Doe",
+            "mutual_spaces": [
+              "52e47e18-9a9d-4663-94c5-abcb18fa783a"
+            ]
+          }
+        }
+      },
+      "user_ids": {}
+    },
+    "errors": {
+      "emails": {},
+      "user_ids": {}
+    }
+  }
+}

--- a/spec/ribose/space_invitation_spec.rb
+++ b/spec/ribose/space_invitation_spec.rb
@@ -24,6 +24,25 @@ RSpec.describe Ribose::SpaceInvitation do
     end
   end
 
+  describe ".mass_create" do
+    it "creates multiple inviations to a space" do
+      space_id = 123_456_789
+
+      attributes = {
+        role_ids: [123_456_789],
+        emails: ["jennie.doe@example.com"],
+        body: "Hi, I would like to join you to this space",
+      }
+
+      stub_ribose_space_invitation_mass_create(space_id, attributes)
+      invitation = Ribose::SpaceInvitation.mass_create(space_id, attributes)
+
+      expect(
+        invitation.success.emails.first[0].to_s,
+      ).to eq(attributes[:emails].first.to_s)
+    end
+  end
+
   describe ".update" do
     it "updates a space invitation" do
       invitation_id = 123_456_789

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -179,6 +179,15 @@ module Ribose
       )
     end
 
+    def stub_ribose_space_invitation_mass_create(space_id, attributes)
+      stub_api_response(
+        :post,
+        "spaces/#{space_id}/invitations/to_space/mass_create",
+        data: { invitation: attributes.merge(space_id: space_id) },
+        filename: "space_mass_invitations",
+      )
+    end
+
     def stub_ribose_space_invitation_resend_api(invitation_id)
       stub_api_response(
         :post,


### PR DESCRIPTION
The Ribose Space Invitation API support both sending out a single and multiple invitations at a time and this commit implement the interface to send out mass invitation to multiple users.

```ruby
Ribose::SpaceInvitation.mass_create(
  space_id,
  emails: ["email-one@example.com"],
  role_ids: ["role-for-email-address-in-sequance"],
  body: "The complete message body for the invitation",
)
```