### PR TITLE
Add interface to list join space requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,14 @@ Ribose::SpaceInvitation.reject(invitation_id)
 Ribose::SpaceInvitation.cancel(invitation_id)
 ```
 
+### Join Space Request
+
+#### List join space requests
+
+```ruby
+Ribose::JoinSpaceRequest.all
+```
+
 ### Calendar
 
 #### List user calendars

--- a/lib/ribose.rb
+++ b/lib/ribose.rb
@@ -17,6 +17,7 @@ require "ribose/space_file"
 require "ribose/conversation"
 require "ribose/message"
 require "ribose/space_invitation"
+require "ribose/join_space_request"
 require "ribose/connection_invitation"
 
 module Ribose

--- a/lib/ribose/join_space_request.rb
+++ b/lib/ribose/join_space_request.rb
@@ -1,0 +1,15 @@
+module Ribose
+  class JoinSpaceRequest < Ribose::Base
+    include Ribose::Actions::All
+
+    private
+
+    def resources_key
+      "join_space_requests"
+    end
+
+    def resources
+      "invitations/join_space_request"
+    end
+  end
+end

--- a/spec/fixtures/join_space_requests.json
+++ b/spec/fixtures/join_space_requests.json
@@ -1,0 +1,34 @@
+{
+  "join_space_requests": [
+    {
+      "id": 27743,
+      "email": null,
+      "body": "John Doe invites you to join `The CLI Space'.  Join now!",
+      "created_at": "2017-09-19T09:32:53.000+00:00",
+      "state": 0,
+      "role_id": 41739,
+      "type": "Invitation::ToSpace",
+      "updated_at": "2017-09-19T09:32:53.000+00:00",
+      "inviter": {
+        "id": "2970d105-5ccc-4a8c-b0c4-ec32d539a00a",
+        "connected": true,
+        "name": "Jennie Doe",
+        "mutual_spaces": []
+      },
+      "space": {
+        "id": "52e47e18-9a9d-4663-94c5-abcb18fa783a",
+        "name": "The CLI Space",
+        "members_count": 1
+      },
+      "invitee": {
+        "id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+        "connected": true,
+        "name": "Jennie Doe",
+        "mutual_spaces": [
+          "268b0407-c3a3-4aad-8693-fdba789f7f0d",
+          "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc"
+        ]
+      }
+    }
+  ]
+}

--- a/spec/ribose/join_space_request_spec.rb
+++ b/spec/ribose/join_space_request_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+
+RSpec.describe Ribose::JoinSpaceRequest do
+  describe ".all" do
+    it "retrieves the list of all join space requests" do
+      stub_ribose_join_space_request_list_api
+      invitations = Ribose::JoinSpaceRequest.all
+
+      expect(invitations.first.id).not_to be_nil
+      expect(invitations.first.type).to eq("Invitation::ToSpace")
+    end
+  end
+end

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -211,6 +211,12 @@ module Ribose
       )
     end
 
+    def stub_ribose_join_space_request_list_api
+      stub_api_response(
+        :get, "invitations/join_space_request", filename: "join_space_requests"
+      )
+    end
+
     private
 
     def ribose_endpoint(endpoint)


### PR DESCRIPTION
This commit utilize the Ribose Join Space Request API and add simple interface to list all of the join space requests, Usages:

```ruby
Ribose::JoinSpaceRequest.all
```