### PR TITLE
Interface to create join space request

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,17 @@ Ribose::SpaceInvitation.cancel(invitation_id)
 Ribose::JoinSpaceRequest.all
 ```
 
+#### Create a join space request
+
+```ruby
+Ribose::JoinSpaceRequest.create(
+  state: 0,
+  space_id: 123_456_789,
+  type: "Invitation::JoinSpaceRequest",
+  body: "Hi, I would like to join to your space",
+)
+```
+
 ### Calendar
 
 #### List user calendars

--- a/lib/ribose/join_space_request.rb
+++ b/lib/ribose/join_space_request.rb
@@ -1,8 +1,17 @@
 module Ribose
   class JoinSpaceRequest < Ribose::Base
     include Ribose::Actions::All
+    include Ribose::Actions::Create
 
     private
+
+    def resource
+      "invitation"
+    end
+
+    def resource_key
+      "join_space_request"
+    end
 
     def resources_key
       "join_space_requests"
@@ -10,6 +19,10 @@ module Ribose
 
     def resources
       "invitations/join_space_request"
+    end
+
+    def validate(space_id:, **attributes)
+      attributes.merge(space_id: space_id)
     end
   end
 end

--- a/spec/fixtures/join_space_request_created.json
+++ b/spec/fixtures/join_space_request_created.json
@@ -1,0 +1,26 @@
+{
+  "join_space_request": {
+    "id": 27766,
+    "email": null,
+    "body": null,
+    "created_at": "2017-09-29T09:00:59.450+00:00",
+    "state": 0,
+    "role_id": null,
+    "type": "Invitation::JoinSpaceRequest",
+    "updated_at": "2017-09-29T09:00:59.547+00:00",
+    "inviter": {
+      "id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+      "connected": true,
+      "name": "John Doe",
+      "mutual_spaces": [
+        "268b0407-c3a3-4aad-8693-fdba789f7f0d",
+        "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc"
+      ]
+    },
+    "space": {
+      "id": "52e47e18-9a9d-4663-94c5-abcb18fa783a",
+      "name": "The CLI Space",
+      "members_count": 1
+    }
+  }
+}

--- a/spec/ribose/join_space_request_spec.rb
+++ b/spec/ribose/join_space_request_spec.rb
@@ -10,4 +10,21 @@ RSpec.describe Ribose::JoinSpaceRequest do
       expect(invitations.first.type).to eq("Invitation::ToSpace")
     end
   end
+
+  describe ".create" do
+    it "creates a new join space request" do
+      attributes = {
+        state: 0,
+        type: "Invitation::JoinSpaceRequest",
+        body: "Hi, I would like to join to your space",
+        space_id: 123_456_789,
+      }
+
+      stub_ribose_join_space_request_create_api(attributes)
+      invitation = Ribose::JoinSpaceRequest.create(attributes)
+
+      expect(invitation.id).not_to be_nil
+      expect(invitation.inviter.name).to eq("John Doe")
+    end
+  end
 end

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -217,6 +217,15 @@ module Ribose
       )
     end
 
+    def stub_ribose_join_space_request_create_api(attributes)
+      stub_api_response(
+        :post,
+        "invitations/join_space_request",
+        data: { invitation: attributes },
+        filename: "join_space_request_created",
+      )
+    end
+
     private
 
     def ribose_endpoint(endpoint)


### PR DESCRIPTION
Ribose user might request to join to another user space, and it also offers an API endpoint for this. This commit utilize that endpoint and adds an interface to create that join request.

```ruby
Ribose::JoinSpaceRequest.create(
  state: 0,
  space_id: 123_456_789,
  type: "Invitation::JoinSpaceRequest",
  body: "Hi, I would like to join to your space",
)
```