### PR TITLE
Interface to accept space join request

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,12 @@ Ribose::JoinSpaceRequest.create(
 )
 ```
 
+#### Accept a join space request
+
+```ruby
+Ribose::JoinSpaceRequest.accept(invitation_id)
+```
+
 ### Calendar
 
 #### List user calendars

--- a/lib/ribose/join_space_request.rb
+++ b/lib/ribose/join_space_request.rb
@@ -3,7 +3,17 @@ module Ribose
     include Ribose::Actions::All
     include Ribose::Actions::Create
 
+    def update
+      update_invitation[resource_key]
+    end
+
+    def self.accept(invitation_id)
+      new(invitation_id: invitation_id, state: 1).update
+    end
+
     private
+
+    attr_reader :invitation_id
 
     def resource
       "invitation"
@@ -23,6 +33,16 @@ module Ribose
 
     def validate(space_id:, **attributes)
       attributes.merge(space_id: space_id)
+    end
+
+    def extract_local_attributes
+      @invitation_id = attributes.delete(:invitation_id)
+    end
+
+    def update_invitation
+      Ribose::Request.put(
+        [resources, invitation_id].join("/"), invitation: attributes
+      )
     end
   end
 end

--- a/spec/fixtures/join_space_request_updated.json
+++ b/spec/fixtures/join_space_request_updated.json
@@ -1,0 +1,25 @@
+{
+  "join_space_request": {
+    "id": 27767,
+    "email": null,
+    "body": null,
+    "created_at": "2017-09-29T10:00:23.000+00:00",
+    "state": 1,
+    "role_id": null,
+    "type": "Invitation::JoinSpaceRequest",
+    "updated_at": "2017-09-29T10:09:23.000+00:00",
+    "inviter": {
+      "id": "2970d105-5ccc-4a8c-b0c4-ec32d539a00a",
+      "connected": false,
+      "name": "John Doe",
+      "mutual_spaces": [
+        "268b0407-c3a3-4aad-8693-fdba789f7f0d"
+      ]
+    },
+    "space": {
+      "id": "268b0407-c3a3-4aad-8693-fdba789f7f0d",
+      "name": "Sample Space",
+      "members_count": 2
+    }
+  }
+}

--- a/spec/ribose/join_space_request_spec.rb
+++ b/spec/ribose/join_space_request_spec.rb
@@ -27,4 +27,17 @@ RSpec.describe Ribose::JoinSpaceRequest do
       expect(invitation.inviter.name).to eq("John Doe")
     end
   end
+
+  describe ".accept" do
+    it "accepts a join request to a space" do
+      invitation_id = 123_456_789
+
+      stub_ribose_join_space_request_update(invitation_id, state: 1)
+      invitation = Ribose::JoinSpaceRequest.accept(invitation_id)
+
+      expect(invitation.state).to eq(1)
+      expect(invitation.id).not_to be_nil
+      expect(invitation.type).to eq("Invitation::JoinSpaceRequest")
+    end
+  end
 end

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -226,6 +226,15 @@ module Ribose
       )
     end
 
+    def stub_ribose_join_space_request_update(invitation_id, attributes)
+      stub_api_response(
+        :put,
+        "invitations/join_space_request/#{invitation_id}",
+        data: { invitation: attributes },
+        filename: "join_space_request_updated",
+      )
+    end
+
     private
 
     def ribose_endpoint(endpoint)


### PR DESCRIPTION
One Ribose user might sent out a request to join a space from one of the other user, but that user will decide if he will accept or decline that request. This commit adds the interface to that will allow user to accept any specific join request.

```ruby
Ribose::JoinSpaceRequest.accept(invitation_id)
```