### PR TITLE
Interface to reject space join request

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,12 @@ Ribose::JoinSpaceRequest.create(
 Ribose::JoinSpaceRequest.accept(invitation_id)
 ```
 
+#### Reject a join space requests
+
+```ruby
+Ribose::JoinSpaceRequest.reject(invitation_id)
+```
+
 ### Calendar
 
 #### List user calendars

--- a/lib/ribose/join_space_request.rb
+++ b/lib/ribose/join_space_request.rb
@@ -11,6 +11,10 @@ module Ribose
       new(invitation_id: invitation_id, state: 1).update
     end
 
+    def self.reject(invitation_id)
+      new(invitation_id: invitation_id, state: 2).update
+    end
+
     private
 
     attr_reader :invitation_id

--- a/spec/ribose/join_space_request_spec.rb
+++ b/spec/ribose/join_space_request_spec.rb
@@ -40,4 +40,17 @@ RSpec.describe Ribose::JoinSpaceRequest do
       expect(invitation.type).to eq("Invitation::JoinSpaceRequest")
     end
   end
+
+  describe ".reject" do
+    it "rejects a join request to a space" do
+      invitation_id = 123_456_789
+
+      stub_ribose_join_space_request_update(invitation_id, state: 2)
+      invitation = Ribose::JoinSpaceRequest.reject(invitation_id)
+
+      expect(invitation.id).not_to be_nil
+      expect(invitation.state).not_to be_nil
+      expect(invitation.type).to eq("Invitation::JoinSpaceRequest")
+    end
+  end
 end


### PR DESCRIPTION
One Ribose user might sent out a request to join a space from one of the other user, but that user will decide if he will accept or decline that request. This commit adds the interface to that will reject the join space request.

```ruby
Ribose::JoinSpaceRequest.reject(invitation_id)
```