### PR TITLE
Add interface to update join space request

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,12 @@ Ribose::JoinSpaceRequest.accept(invitation_id)
 Ribose::JoinSpaceRequest.reject(invitation_id)
 ```
 
+#### Update an join space requests
+
+```ruby
+Ribose::JoinSpaceRequest.update(invitation_id, new_attributes_hash)
+```
+
 ### Calendar
 
 #### List user calendars

--- a/lib/ribose/join_space_request.rb
+++ b/lib/ribose/join_space_request.rb
@@ -15,6 +15,10 @@ module Ribose
       new(invitation_id: invitation_id, state: 2).update
     end
 
+    def self.update(invitation_id, attributes)
+      new(attributes.merge(invitation_id: invitation_id)).update
+    end
+
     private
 
     attr_reader :invitation_id

--- a/spec/ribose/join_space_request_spec.rb
+++ b/spec/ribose/join_space_request_spec.rb
@@ -28,6 +28,20 @@ RSpec.describe Ribose::JoinSpaceRequest do
     end
   end
 
+  describe ".update" do
+    it "updates the details for a join request" do
+      invitation_id = 123_456_789
+      attributes = { state: 1, role_id: 101 }
+
+      stub_ribose_join_space_request_update(invitation_id, attributes)
+      invitation = Ribose::JoinSpaceRequest.update(invitation_id, attributes)
+
+      expect(invitation.id).not_to be_nil
+      expect(invitation.state).not_to be_nil
+      expect(invitation.type).to eq("Invitation::JoinSpaceRequest")
+    end
+  end
+
   describe ".accept" do
     it "accepts a join request to a space" do
       invitation_id = 123_456_789


### PR DESCRIPTION
In the previous commits, we have added the `accept` and `reject` interface for join space request, but on the underneath those are actually invoking the `update` method with specified `state`.

This commit expose that internal `update` interface, so user can use this one to update some details for any of the existing join space request.

```ruby
Ribose::JoinSpaceRequest.update(
  invitation_id, new_allowed_attributes_hash,
)
```