### PR TITLE
Extract the `update` action to a module

### DIFF
--- a/lib/ribose/actions.rb
+++ b/lib/ribose/actions.rb
@@ -1,6 +1,7 @@
 require "ribose/actions/all"
 require "ribose/actions/fetch"
 require "ribose/actions/create"
+require "ribose/actions/update"
 
 module Ribose
   module Actions

--- a/lib/ribose/actions/update.rb
+++ b/lib/ribose/actions/update.rb
@@ -1,0 +1,67 @@
+require "ribose/actions/base"
+
+module Ribose
+  module Actions
+    module Update
+      extend Ribose::Actions::Base
+
+      # Update a resource
+      #
+      # @return [Sawyer::Resource] Update resource response
+      #
+      def update
+        update_resource[resource_key]
+      end
+
+      private
+
+      # Resource
+      #
+      # This method should return the resource name that should
+      # be used to orgnize the request body for create operation
+      #
+      def resource; end
+
+      # Resource key
+      #
+      # This method should return the key that is used as a root
+      # elemenet in the response for create operation, ideally it
+      # is same as the `resource` method but some endpoit might
+      # need some variation.
+      #
+      def resource_key
+        resource
+      end
+
+      # Resources
+      #
+      # The plurarl version for the resource / resrouce key.
+      #
+      def resources
+        [resource, "s"].join("")
+      end
+
+      def resource_update_path
+        [resources, resource_id].join("/")
+      end
+
+      def update_resource
+        Ribose::Request.put(
+          resource_update_path, resource.to_sym => attributes
+        )
+      end
+
+      module ClassMethods
+        # Update a resource
+        #
+        # @param resource_id [String] The Resource UUID
+        # @param attributes [Hash] New attributes as Hash
+        # @return [Sawyer::Resource] The Updated Resource
+        #
+        def update(resource_id, attributes)
+          new(attributes.merge(resource_id: resource_id)).update
+        end
+      end
+    end
+  end
+end

--- a/lib/ribose/connection_invitation.rb
+++ b/lib/ribose/connection_invitation.rb
@@ -2,10 +2,7 @@ module Ribose
   class ConnectionInvitation < Ribose::Base
     include Ribose::Actions::All
     include Ribose::Actions::Fetch
-
-    def update
-      update_invitation[resource_key]
-    end
+    include Ribose::Actions::Update
 
     def create
       create_invitations[:invitations]
@@ -16,11 +13,11 @@ module Ribose
     end
 
     def self.accept(invitation_id)
-      new(invitation_id: invitation_id, state: 1).update
+      new(resource_id: invitation_id, state: 1).update
     end
 
     def self.reject(invitation_id)
-      new(invitation_id: invitation_id, state: 2).update
+      new(resource_id: invitation_id, state: 2).update
     end
 
     def self.cancel(invitation_id)
@@ -55,13 +52,6 @@ module Ribose
       Ribose::Request.post(
         [resources, "mass_create"].join("/"),
         invitation: { body: attributes[:body], emails: attributes[:emails] },
-      )
-    end
-
-    def update_invitation
-      Ribose::Request.put(
-        [resources, invitation_id].join("/"),
-        invitation: { state: attributes[:state] },
       )
     end
   end

--- a/lib/ribose/join_space_request.rb
+++ b/lib/ribose/join_space_request.rb
@@ -2,26 +2,21 @@ module Ribose
   class JoinSpaceRequest < Ribose::Base
     include Ribose::Actions::All
     include Ribose::Actions::Create
-
-    def update
-      update_invitation[resource_key]
-    end
+    include Ribose::Actions::Update
 
     def self.accept(invitation_id)
-      new(invitation_id: invitation_id, state: 1).update
+      new(resource_id: invitation_id, state: 1).update
     end
 
     def self.reject(invitation_id)
-      new(invitation_id: invitation_id, state: 2).update
+      new(resource_id: invitation_id, state: 2).update
     end
 
     def self.update(invitation_id, attributes)
-      new(attributes.merge(invitation_id: invitation_id)).update
+      new(attributes.merge(resource_id: invitation_id)).update
     end
 
     private
-
-    attr_reader :invitation_id
 
     def resource
       "invitation"
@@ -45,12 +40,6 @@ module Ribose
 
     def extract_local_attributes
       @invitation_id = attributes.delete(:invitation_id)
-    end
-
-    def update_invitation
-      Ribose::Request.put(
-        [resources, invitation_id].join("/"), invitation: attributes
-      )
     end
   end
 end

--- a/lib/ribose/message.rb
+++ b/lib/ribose/message.rb
@@ -2,6 +2,7 @@ module Ribose
   class Message
     include Ribose::Actions::All
     include Ribose::Actions::Create
+    include Ribose::Actions::Update
 
     # Message initilaiztion
     #
@@ -15,10 +16,6 @@ module Ribose
       @attributes = attributes
       @conversation_id = conversation_id
       @message_id = attributes.delete(:message_id)
-    end
-
-    def update
-      update_message[:message]
     end
 
     def remove
@@ -72,7 +69,8 @@ module Ribose
 
     private
 
-    attr_reader :space_id, :message_id, :conversation_id, :attributes
+    attr_reader :space_id, :conversation_id, :message_id, :attributes
+    alias_method :resource_id, :message_id
 
     def resource
       "message"
@@ -88,12 +86,6 @@ module Ribose
 
     def conversations
       ["spaces", space_id, "conversation/conversations"].join("/")
-    end
-
-    def update_message
-      Ribose::Request.put(
-        [resources, message_id].join("/"), message: attributes
-      )
     end
   end
 end

--- a/lib/ribose/space_invitation.rb
+++ b/lib/ribose/space_invitation.rb
@@ -2,10 +2,7 @@ module Ribose
   class SpaceInvitation < Ribose::Base
     include Ribose::Actions::All
     include Ribose::Actions::Create
-
-    def update
-      update_invitation[resource_key]
-    end
+    include Ribose::Actions::Update
 
     def mass_create
       create_invitations[:invitations]
@@ -16,11 +13,11 @@ module Ribose
     end
 
     def self.update(invitation_id, attributes)
-      new(attributes.merge(invitation_id: invitation_id)).update
+      new(attributes.merge(resource_id: invitation_id)).update
     end
 
     def self.accept(invitation_id)
-      new(invitation_id: invitation_id, state: 1).update
+      new(resource_id: invitation_id, state: 1).update
     end
 
     def self.resend(invitation_id)
@@ -30,7 +27,7 @@ module Ribose
     end
 
     def self.reject(invitation_id)
-      new(invitation_id: invitation_id, state: 2).update
+      new(resource_id: invitation_id, state: 2).update
     end
 
     def self.cancel(invitation_id)
@@ -38,8 +35,6 @@ module Ribose
     end
 
     private
-
-    attr_reader :invitation_id
 
     def resource
       "invitation"
@@ -67,12 +62,6 @@ module Ribose
 
     def create_invitations
       Ribose::Request.post(mass_create_path, invitation: attributes)
-    end
-
-    def update_invitation
-      Ribose::Request.put(
-        [resources, invitation_id].join("/"), invitation: attributes
-      )
     end
 
     def mass_create_path

--- a/spec/ribose/actions/update_spec.rb
+++ b/spec/ribose/actions/update_spec.rb
@@ -1,0 +1,36 @@
+require "spec_helper"
+require "ribose/actions/update"
+
+RSpec.describe "TestUpdateAction" do
+  describe ".update" do
+    it "updates a resource with provided details" do
+      resource_id = 123_456_789
+      attributes = { attribute_name: "attribute_value" }
+
+      stub_ribose_resource_update_api_call(resource_id, attributes)
+      resource = Ribose::TestUpdateAction.update(resource_id, attributes)
+
+      expect(resource.id).not_to be_nil
+    end
+  end
+
+  module Ribose
+    class TestUpdateAction < Ribose::Base
+      include Ribose::Actions::Update
+
+      private
+
+      def resource
+        "space"
+      end
+    end
+  end
+
+  def stub_ribose_resource_update_api_call(resource_id, attributes)
+    resource_path = ["spaces", resource_id].join("/")
+
+    stub_api_response(
+      :put, resource_path, data: { space: attributes }, filename: "space"
+    )
+  end
+end


### PR DESCRIPTION
There are couple of resources that has the update functionality and most of them are repeating the same action over and over in each of them. This commit extract that `update` action to a new module and cleanup all of those duplications.