### PR TITLE
Extract out resource related helpers

### DIFF
--- a/lib/ribose/actions/all.rb
+++ b/lib/ribose/actions/all.rb
@@ -13,31 +13,15 @@ module Ribose
       # @return [Array <Sawyer::Resource>]
       #
       def all(options = {})
-        response = Ribose::Request.get(resources, options)
+        response = Ribose::Request.get(resources_path, options)
         extract_root(response) || response
       end
 
       private
 
-      # Resources Key
-      #
-      # This value represents the root element in the API response.
-      # Currently, Ribose is using the plural resource name as the
-      # the key.
-      #
-      # By default we will use that to extract the details, but if
-      # some resource are different then we can override this and
-      # that will be used instead.
-      #
-      # @return [String]
-      #
-      def resources_key
-        resources.to_s
-      end
-
       def extract_root(response)
-        unless resources_key.nil?
-          response[resources_key]
+        unless resources.nil?
+          response[resources]
         end
       end
 

--- a/lib/ribose/actions/create.rb
+++ b/lib/ribose/actions/create.rb
@@ -6,28 +6,10 @@ module Ribose
       extend Ribose::Actions::Base
 
       def create
-        create_resource[resource_key]
+        create_resource[resource]
       end
 
       private
-
-      # Resource
-      #
-      # This method should return the resource name that should
-      # be used to orgnize the request body for create operation
-      #
-      def resource; end
-
-      # Response key
-      #
-      # This method should return the key that is used as a root
-      # elemenet in the response for create operation, ideally it
-      # is same as the `resource` method but some endpoit might
-      # need some variation.
-      #
-      def resource_key
-        resource
-      end
 
       # Attribute validations
       #
@@ -40,11 +22,11 @@ module Ribose
       end
 
       def request_body(attributes)
-        { resource.to_sym => validate(attributes) }
+        { resource_key.to_sym => validate(attributes) }
       end
 
       def create_resource
-        Ribose::Request.post(resources, request_body(attributes))
+        Ribose::Request.post(resources_path, request_body(attributes))
       end
 
       module ClassMethods

--- a/lib/ribose/actions/fetch.rb
+++ b/lib/ribose/actions/fetch.rb
@@ -13,27 +13,15 @@ module Ribose
       # @return [Sawyer::Resource]
       #
       def fetch
-        response = Request.get([resources, resource_id].join("/"))
+        response = Request.get(resource_path)
         extract_resource(response) || response
       end
 
       private
 
-      # Single Resource
-      #
-      # Returns the singular version of the resoruces, and if some
-      # resource usages different pattern then we can override this
-      # method and that return value will be used.
-      #
-      # @return [String]
-      #
-      def resource_key
-        resources[0...-1]
-      end
-
       def extract_resource(response)
-        unless resource_key.nil?
-          response[resource_key.to_s]
+        unless resource.nil?
+          response[resource.to_s]
         end
       end
 

--- a/lib/ribose/actions/update.rb
+++ b/lib/ribose/actions/update.rb
@@ -8,47 +8,14 @@ module Ribose
       # Update a resource
       #
       # @return [Sawyer::Resource] Update resource response
-      #
       def update
-        update_resource[resource_key]
+        update_resource[resource]
       end
 
       private
 
-      # Resource
-      #
-      # This method should return the resource name that should
-      # be used to orgnize the request body for create operation
-      #
-      def resource; end
-
-      # Resource key
-      #
-      # This method should return the key that is used as a root
-      # elemenet in the response for create operation, ideally it
-      # is same as the `resource` method but some endpoit might
-      # need some variation.
-      #
-      def resource_key
-        resource
-      end
-
-      # Resources
-      #
-      # The plurarl version for the resource / resrouce key.
-      #
-      def resources
-        [resource, "s"].join("")
-      end
-
-      def resource_update_path
-        [resources, resource_id].join("/")
-      end
-
       def update_resource
-        Ribose::Request.put(
-          resource_update_path, resource.to_sym => attributes
-        )
+        Ribose::Request.put(resource_path, resource_key.to_sym => attributes)
       end
 
       module ClassMethods
@@ -57,7 +24,6 @@ module Ribose
         # @param resource_id [String] The Resource UUID
         # @param attributes [Hash] New attributes as Hash
         # @return [Sawyer::Resource] The Updated Resource
-        #
         def update(resource_id, attributes)
           new(attributes.merge(resource_id: resource_id)).update
         end

--- a/lib/ribose/app_data.rb
+++ b/lib/ribose/app_data.rb
@@ -4,8 +4,12 @@ module Ribose
 
     private
 
-    def resources
+    def resource
       "app_data"
+    end
+
+    def resources
+      resource
     end
   end
 end

--- a/lib/ribose/app_relation.rb
+++ b/lib/ribose/app_relation.rb
@@ -5,8 +5,8 @@ module Ribose
 
     private
 
-    def resources
-      "app_relations"
+    def resource
+      "app_relation"
     end
   end
 end

--- a/lib/ribose/base.rb
+++ b/lib/ribose/base.rb
@@ -1,5 +1,9 @@
+require "ribose/resource_helper"
+
 module Ribose
   class Base
+    include Ribose::ResourceHelper
+
     def initialize(attributes = {})
       @attributes = attributes
       extract_base_attributes

--- a/lib/ribose/calendar.rb
+++ b/lib/ribose/calendar.rb
@@ -4,7 +4,11 @@ module Ribose
 
     private
 
-    def resources
+    def resource
+      "calendar"
+    end
+
+    def resources_path
       "calendar/calendar"
     end
   end

--- a/lib/ribose/connection.rb
+++ b/lib/ribose/connection.rb
@@ -27,7 +27,11 @@ module Ribose
 
     private
 
-    def resources
+    def resource
+      "connection"
+    end
+
+    def resources_path
       "people/connections"
     end
   end

--- a/lib/ribose/connection_invitation.rb
+++ b/lib/ribose/connection_invitation.rb
@@ -26,21 +26,15 @@ module Ribose
 
     private
 
-    attr_reader :invitation_id
-
     def resource
-      "invitation"
-    end
-
-    def resource_key
       "to_connection"
     end
 
-    def resources_key
-      [resource_key, "s"].join
+    def resource_key
+      "invitation"
     end
 
-    def resources
+    def resources_path
       "invitations/to_connection"
     end
 
@@ -50,7 +44,7 @@ module Ribose
 
     def create_invitations
       Ribose::Request.post(
-        [resources, "mass_create"].join("/"),
+        [resources_path, "mass_create"].join("/"),
         invitation: { body: attributes[:body], emails: attributes[:emails] },
       )
     end

--- a/lib/ribose/conversation.rb
+++ b/lib/ribose/conversation.rb
@@ -4,7 +4,7 @@ module Ribose
     include Ribose::Actions::Create
 
     def remove
-      Ribose::Request.delete([resources, conversation_id].join("/"))
+      Ribose::Request.delete(resource_path)
     end
 
     # Listing Space Conversations
@@ -34,6 +34,7 @@ module Ribose
     private
 
     attr_reader :space_id, :conversation_id
+    alias_method :resource_id, :conversation_id
 
     def extract_local_attributes
       @space_id = attributes.delete(:space_id)
@@ -44,7 +45,7 @@ module Ribose
       "conversation"
     end
 
-    def resources
+    def resources_path
       ["spaces", space_id, "conversation", "conversations"].join("/")
     end
 

--- a/lib/ribose/feed.rb
+++ b/lib/ribose/feed.rb
@@ -4,8 +4,8 @@ module Ribose
 
     private
 
-    def resources
-      "feeds"
+    def resource
+      "feed"
     end
   end
 end

--- a/lib/ribose/join_space_request.rb
+++ b/lib/ribose/join_space_request.rb
@@ -19,18 +19,14 @@ module Ribose
     private
 
     def resource
-      "invitation"
-    end
-
-    def resource_key
       "join_space_request"
     end
 
-    def resources_key
-      "join_space_requests"
+    def resource_key
+      "invitation"
     end
 
-    def resources
+    def resources_path
       "invitations/join_space_request"
     end
 

--- a/lib/ribose/leaderboard.rb
+++ b/lib/ribose/leaderboard.rb
@@ -4,7 +4,15 @@ module Ribose
 
     private
 
+    def resource
+      "leaderboard"
+    end
+
     def resources
+      resource
+    end
+
+    def resources_path
       "activity_point/leaderboard"
     end
   end

--- a/lib/ribose/member.rb
+++ b/lib/ribose/member.rb
@@ -19,12 +19,12 @@ module Ribose
 
     attr_reader :space_id
 
-    def resources
-      ["spaces", space_id, "members"].join("/")
+    def resource
+      "spaces_user"
     end
 
-    def resources_key
-      "spaces_users"
+    def resources_path
+      ["spaces", space_id, "members"].join("/")
     end
 
     def extract_local_attributes

--- a/lib/ribose/message.rb
+++ b/lib/ribose/message.rb
@@ -1,5 +1,7 @@
 module Ribose
   class Message
+    include Ribose::ResourceHelper
+
     include Ribose::Actions::All
     include Ribose::Actions::Create
     include Ribose::Actions::Update
@@ -19,7 +21,7 @@ module Ribose
     end
 
     def remove
-      Ribose::Request.delete([resources, message_id].join("/"))
+      Ribose::Request.delete(resource_path)
     end
 
     # Listing Conversation Messages
@@ -76,15 +78,15 @@ module Ribose
       "message"
     end
 
-    def resources
-      [conversations, conversation_id, "messages"].join("/")
-    end
-
     def validate(attributes)
       attributes.merge(conversation_id: conversation_id)
     end
 
-    def conversations
+    def resources_path
+      [conversations_path, conversation_id, "messages"].join("/")
+    end
+
+    def conversations_path
       ["spaces", space_id, "conversation/conversations"].join("/")
     end
   end

--- a/lib/ribose/resource_helper.rb
+++ b/lib/ribose/resource_helper.rb
@@ -1,0 +1,81 @@
+module Ribose
+  module ResourceHelper
+    # Resource
+    #
+    # This is the key interface for any resource and every single
+    # resource should implement this method.Ideally this should
+    # reflect resource name in singular form, eg: +space+.
+    #
+    # Once we've this method implemented then this module will try
+    # to auto-generate all of the related helper methods, but if
+    # we need something different that the standard format then we
+    # can always overirde that in those classes.
+    #
+    # @return resrouce [String] The singular form of the Resource
+    def resource
+      raise NotImplementedError
+    end
+
+    # Resource Id
+    #
+    # The id for the key component of any of the classes in
+    # Ribose module, ideally we will have that one as default
+    # attribtue to the base class, but we can override it if
+    # necessary.
+    #
+    # @return resource_id [String] The id/uuid for a Resource
+    def resource_id
+      raise NotImplementedError
+    end
+
+    # Resources
+    #
+    # The plural version of the resoruce name, ideally we will
+    # use this one to to identify an array or resources.
+    #
+    # @return resources [String] The plural form of the Resource
+    def resources
+      [resource, "s"].join
+    end
+
+    # Resource Key
+    #
+    # The resource key is the key that we use to build any of
+    # the post/put request body, and ideally it's the resoruce
+    # value, but occassionally it might be diffrent for any of
+    # the reason, so this method will keep that on portable.
+    #
+    # @return resource_key [String] The key to build a request
+    def resource_key
+      resource
+    end
+
+    # Resources Path
+    #
+    # This represent a restfull resoruce path, and internally
+    # this will be used to build the the api endpoint path for
+    # any specifies resources.
+    #
+    # Based on the Ribose API structure it's pretty similiar
+    # to the resources value with some minor exception of the
+    # nested resoruces, so we are keeping the +resources+ as
+    # default but we can override this when necessary.
+    #
+    # @return resource_path [String] The endpoit for Resources
+    def resources_path
+      resources
+    end
+
+    # Resource Path
+    #
+    # This represent a single resource in a Restfull API. In
+    # Ribose API structure, it's `resources/:id`, so we will
+    # use that one as default. If we need something different
+    # then please override this method.
+    #
+    # @return resoruce_path [String] The Single Resource path
+    def resource_path
+      [resources_path, resource_id].join("/")
+    end
+  end
+end

--- a/lib/ribose/setting.rb
+++ b/lib/ribose/setting.rb
@@ -7,8 +7,8 @@ module Ribose
 
     private
 
-    def resources
-      "settings"
+    def resource
+      "setting"
     end
   end
 end

--- a/lib/ribose/space.rb
+++ b/lib/ribose/space.rb
@@ -22,10 +22,6 @@ module Ribose
       "space"
     end
 
-    def resources
-      "spaces"
-    end
-
     def extract_local_attributes
       @space = attributes.delete(:space)
     end

--- a/lib/ribose/space_file.rb
+++ b/lib/ribose/space_file.rb
@@ -20,11 +20,11 @@ module Ribose
 
     attr_reader :space_id
 
-    def resources_key
-      "files"
+    def resource
+      "file"
     end
 
-    def resources
+    def resources_path
       ["spaces", space_id, "file", "files"].join("/")
     end
 

--- a/lib/ribose/space_invitation.rb
+++ b/lib/ribose/space_invitation.rb
@@ -37,18 +37,14 @@ module Ribose
     private
 
     def resource
-      "invitation"
-    end
-
-    def resource_key
       "to_space"
     end
 
-    def resources_key
-      [resource_key, "s"].join
+    def resource_key
+      "invitation"
     end
 
-    def resources
+    def resources_path
       "invitations/to_space"
     end
 

--- a/lib/ribose/stream.rb
+++ b/lib/ribose/stream.rb
@@ -4,8 +4,12 @@ module Ribose
 
     private
 
-    def resources
+    def resource
       "stream"
+    end
+
+    def resources
+      resource
     end
   end
 end

--- a/lib/ribose/widget.rb
+++ b/lib/ribose/widget.rb
@@ -4,8 +4,8 @@ module Ribose
 
     private
 
-    def resources
-      "widgets"
+    def resource
+      "widget"
     end
   end
 end

--- a/spec/ribose/actions/fetch_spec.rb
+++ b/spec/ribose/actions/fetch_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe "TestFetchAction" do
 
       private
 
-      def resources
-        "spaces"
+      def resource
+        "space"
       end
     end
   end

--- a/spec/ribose/resource_helper_spec.rb
+++ b/spec/ribose/resource_helper_spec.rb
@@ -1,0 +1,58 @@
+require "spec_helper"
+require "ribose/resource_helper"
+
+RSpec.describe "TestResourceHelper" do
+  describe "helpers" do
+    context "without any customization" do
+      it "builds and returns the default values" do
+        resource = Ribose::TestResourceHelper.new
+
+        expect(resource.resource).to eq("resource")
+        expect(resource.resources).to eq("resources")
+
+        expect(resource.resources_path).to eq("resources")
+        expect(resource.resource_path).to eq("resources/123456789")
+      end
+
+      context "with customization" do
+        it "returns the custom values when available" do
+          custom_resource = Ribose::CustomResourceHelper.new
+
+          expect(custom_resource.resources).to eq("resources")
+          expect(custom_resource.resources_path).to eq("resource/nested")
+          expect(custom_resource.resource_path).to eq("custom/nested/123456789")
+        end
+      end
+    end
+  end
+
+  module Ribose
+    class TestResourceHelper
+      include Ribose::ResourceHelper
+
+      def resource
+        "resource"
+      end
+
+      def resource_id
+        123_456_789
+      end
+    end
+
+    class CustomResourceHelper
+      include Ribose::ResourceHelper
+
+      def resource
+        "resource"
+      end
+
+      def resources_path
+        "resource/nested"
+      end
+
+      def resource_path
+        "custom/nested/123456789"
+      end
+    end
+  end
+end


### PR DESCRIPTION
In the current version, we have extracted out multiple actions and each of them are dependent on some sort of helper methods to build the appropriate resource, resource path, everything related to do a successful request and there are a couple of duplications between those helpers.

And even worst, we have some inconsistency between those name and their behavior, which might make it quite complex in the
future.

This commit extracted out those helpers to a new, dedicated module, so everything in one place and it also cleanup the existing duplications. This should also keep a consistency