### PR TITLE
Interface to fetch a calender details

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,12 @@ fetch the calendar details for the currently configured user.
 Ribose::Calendar.all
 ```
 
+#### Fetch c calendar
+
+```ruby
+Ribose::Calendar.fetch(calendar_id)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/ribose/calendar.rb
+++ b/lib/ribose/calendar.rb
@@ -1,6 +1,7 @@
 module Ribose
   class Calendar < Ribose::Base
     include Ribose::Actions::All
+    include Ribose::Actions::Fetch
 
     private
 

--- a/spec/fixtures/calendar.json
+++ b/spec/fixtures/calendar.json
@@ -1,34 +1,12 @@
 {
-  "filter": {
-    "enabled": [
-      19706,
-      19707
-    ],
-    "userSetting": []
-  },
-  "cal_info": [
-    {
-      "id": 19706,
-      "owner_type": "User",
-      "name": "john.doe",
-      "owner_id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
-      "owner_name": "Personal",
-      "display_name": "john.doe (Personal)",
-      "can_manage": true,
-      "can_create_event": true
-    },
-    {
-      "id": 19707,
-      "owner_type": "Space",
-      "name": "Work",
-      "owner_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc",
-      "owner_name": "Work",
-      "display_name": "Work (Work)",
-      "can_manage": true,
-      "can_create_event": true
-    }
-  ],
-  "spaces_permission": {
-    "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc": true
+  "calendar": {
+    "id": 19816,
+    "owner_type": "User",
+    "name": "Sample 101",
+    "owner_id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+    "owner_name": "Personal",
+    "display_name": "Sample 101 (Personal)",
+    "can_manage": true,
+    "can_create_event": true
   }
 }

--- a/spec/fixtures/calendars.json
+++ b/spec/fixtures/calendars.json
@@ -1,0 +1,34 @@
+{
+  "filter": {
+    "enabled": [
+      19706,
+      19707
+    ],
+    "userSetting": []
+  },
+  "cal_info": [
+    {
+      "id": 19706,
+      "owner_type": "User",
+      "name": "john.doe",
+      "owner_id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+      "owner_name": "Personal",
+      "display_name": "john.doe (Personal)",
+      "can_manage": true,
+      "can_create_event": true
+    },
+    {
+      "id": 19707,
+      "owner_type": "Space",
+      "name": "Work",
+      "owner_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc",
+      "owner_name": "Work",
+      "display_name": "Work (Work)",
+      "can_manage": true,
+      "can_create_event": true
+    }
+  ],
+  "spaces_permission": {
+    "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc": true
+  }
+}

--- a/spec/ribose/calendar_spec.rb
+++ b/spec/ribose/calendar_spec.rb
@@ -2,13 +2,26 @@ require "spec_helper"
 
 RSpec.describe Ribose::Calendar do
   describe ".all" do
-    it "retrieves the details for a calendar" do
+    it "retrieves the list of user calenders" do
       stub_ribose_calendar_list_api
       calendar = Ribose::Calendar.all
 
       expect(calendar.cal_info.first.id).not_to be_nil
       expect(calendar.cal_info.first.owner_type).to eq("User")
       expect(calendar.cal_info.first.can_manage).to be_truthy
+    end
+  end
+
+  describe ".fetch" do
+    it "retrieves the details for a calendar" do
+      calendar_id = 123_456_789
+
+      stub_ribose_calendar_fetch_api(calendar_id)
+      calendar = Ribose::Calendar.fetch(calendar_id)
+
+      expect(calendar.id).not_to be_nil
+      expect(calendar.owner_type).to eq("User")
+      expect(calendar.name).to eq("Sample 101")
     end
   end
 end

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -49,7 +49,15 @@ module Ribose
     end
 
     def stub_ribose_calendar_list_api
-      stub_api_response(:get, "calendar/calendar", filename: "calendar")
+      stub_api_response(:get, "calendar/calendar", filename: "calendars")
+    end
+
+    def stub_ribose_calendar_fetch_api(calender_id)
+      stub_api_response(
+        :get,
+        "calendar/calendar/#{calender_id}",
+        filename: "calendar",
+      )
     end
 
     def stub_ribose_app_data_api


### PR DESCRIPTION
The Calendar endpoints offers the `calendar/:calender_id` endpoint to retrieve the details for a calender, this commit utilize that endpoint and provides a binding through our API client.

```ruby
Ribose::Calendar.fetch(calendar_id)
```