### PR TITLE
Add interface to create a new calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,10 +443,20 @@ fetch the calendar details for the currently configured user.
 Ribose::Calendar.all
 ```
 
-#### Fetch c calendar
+#### Fetch a calendar
 
 ```ruby
 Ribose::Calendar.fetch(calendar_id)
+```
+
+#### Create a calendar
+
+```ruby
+Ribose::Calendar.create(
+  owner_type: "User",
+  owner_id: "The Owner UUID",
+  name: "The name for the calendar",
+)
 ```
 
 ## Development

--- a/lib/ribose/calendar.rb
+++ b/lib/ribose/calendar.rb
@@ -2,6 +2,7 @@ module Ribose
   class Calendar < Ribose::Base
     include Ribose::Actions::All
     include Ribose::Actions::Fetch
+    include Ribose::Actions::Create
 
     private
 
@@ -11,6 +12,10 @@ module Ribose
 
     def resources_path
       "calendar/calendar"
+    end
+
+    def validate(name:, **attributes)
+      attributes.merge(name: name)
     end
   end
 end

--- a/spec/ribose/calendar_spec.rb
+++ b/spec/ribose/calendar_spec.rb
@@ -24,4 +24,16 @@ RSpec.describe Ribose::Calendar do
       expect(calendar.name).to eq("Sample 101")
     end
   end
+
+  describe ".create" do
+    it "creates a new calendar with provided details" do
+      calendar_attributes = { owner_type: "User", name: "Sample" }
+
+      stub_ribose_calendar_create_api(calendar_attributes)
+      calendar = Ribose::Calendar.create(calendar_attributes)
+
+      expect(calendar.id).not_to be_nil
+      expect(calendar.owner_type).to eq("User")
+    end
+  end
 end

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -60,6 +60,15 @@ module Ribose
       )
     end
 
+    def stub_ribose_calendar_create_api(attributes)
+      stub_api_response(
+        :post,
+        "calendar/calendar",
+        data: { calendar: attributes },
+        filename: "calendar",
+      )
+    end
+
     def stub_ribose_app_data_api
       stub_api_response(:get, "app_data", filename: "app_data")
     end


### PR DESCRIPTION
Ribose API offers `POST /calendar/calendar` endpoint to create a new calendar for user, and this commit utilize that endpoint and provide the ruby binding to create calendar through the client

```ruby
Ribose::Calendar.create(
  owner_type: "User",
  owner_id: "The Owner UUID",
  name: "The name for the calendar",
)
```