### PR TITLE
Interface to send out sign up request

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,14 @@ Ribose::Calendar.create(
 )
 ```
 
+### User
+
+#### Create a signup request
+
+```ruby
+Ribose::User.create(email: "user@example.com", **other_attributes)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/ribose.rb
+++ b/lib/ribose.rb
@@ -19,6 +19,7 @@ require "ribose/message"
 require "ribose/space_invitation"
 require "ribose/join_space_request"
 require "ribose/connection_invitation"
+require "ribose/user"
 
 module Ribose
   def self.root

--- a/lib/ribose/user.rb
+++ b/lib/ribose/user.rb
@@ -1,0 +1,23 @@
+module Ribose
+  class User < Ribose::Base
+    include Ribose::Actions::Create
+
+    def create
+      create_resource
+    end
+
+    private
+
+    def resource
+      "user"
+    end
+
+    def resources_path
+      "signup_requests"
+    end
+
+    def validate(email:, **attributes)
+      attributes.merge(email: email)
+    end
+  end
+end

--- a/spec/ribose/user_spec.rb
+++ b/spec/ribose/user_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+
+RSpec.describe Ribose::User do
+  describe ".create" do
+    it "creates a new signup request for user" do
+      user_attributes = { email: "john.doe@example.com" }
+      stub_ribose_app_user_create_api(user_attributes)
+
+      expect do
+        Ribose::User.create(user_attributes)
+      end.not_to raise_error
+    end
+  end
+end

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -69,6 +69,15 @@ module Ribose
       )
     end
 
+    def stub_ribose_app_user_create_api(attributes)
+      stub_api_response(
+        :post,
+        "signup_requests",
+        data: { user: attributes },
+        filename: "empty",
+      )
+    end
+
     def stub_ribose_app_data_api
       stub_api_response(:get, "app_data", filename: "app_data")
     end


### PR DESCRIPTION
The way Ribose User registration works is bit different, first we would have to generate a sing up request and that will send out an email with a temporary OTP to create an activate an account. This commit implements the first part, so using this interface user can send out the sign up invitation.

```ruby
Ribose::User.create(email: "user@example.com", **other_attributes)
```

Ref: #45