### PR TITLE
Add interface to active a user account

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,16 @@ Ribose::Calendar.create(
 Ribose::User.create(email: "user@example.com", **other_attributes)
 ```
 
+#### Activate a signup request
+
+```ruby
+Ribose::User.activate(
+  email: "user@example.com",
+  password: "ASecureUserPassword",
+  otp: "OTP Recived via the Email",
+)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/ribose/user.rb
+++ b/lib/ribose/user.rb
@@ -6,6 +6,22 @@ module Ribose
       create_resource
     end
 
+    def activate
+      Ribose::Request.post("signup.user", user: attributes, auth_header: false)
+    end
+
+    # Activate a user
+    #
+    # @param email [String] The registering user email
+    # @param password [String] A strong password for login
+    # @param otp [String] The OTP received via the email
+    # @param attributes [Hash] The other attributes as Hash.
+    # @return [Sawyer::Resoruce] The newly activated user
+    #
+    def self.activate(email:, password:, otp:, **attributes)
+      new(attributes.merge(email: email, password: password, otp: otp)).activate
+    end
+
     private
 
     def resource

--- a/spec/fixtures/user_activated.json
+++ b/spec/fixtures/user_activated.json
@@ -1,0 +1,6 @@
+{
+  "id": "94ef494b",
+  "name": "John Doe",
+  "connected": true,
+  "mutual_spaces": []
+}

--- a/spec/ribose/user_spec.rb
+++ b/spec/ribose/user_spec.rb
@@ -1,6 +1,9 @@
 require "spec_helper"
 
 RSpec.describe Ribose::User do
+  before { restore_to_default_config }
+  after { set_configuration_for_test_env }
+
   describe ".create" do
     it "creates a new signup request for user" do
       user_attributes = { email: "john.doe@example.com" }
@@ -9,6 +12,37 @@ RSpec.describe Ribose::User do
       expect do
         Ribose::User.create(user_attributes)
       end.not_to raise_error
+    end
+  end
+
+  describe ".activate" do
+    it "complete the user signup process" do
+      stub_ribose_app_user_activate_api(user_attributes)
+      user = Ribose::User.activate(user_attributes)
+
+      expect(user.id).not_to be_nil
+      expect(user.name).to eq("John Doe")
+      expect(user.connected).to be_truthy
+    end
+  end
+
+  def user_attributes
+    @user_attributes ||= {
+      email: "john.doe@example.com",
+      password: "SecurePassword",
+      otp: "OTP_RECEIVED_VIA_EMAIL",
+    }
+  end
+
+  def restore_to_default_config
+    Ribose.configuration.api_token = nil
+    Ribose.configuration.user_email = nil
+  end
+
+  def set_configuration_for_test_env
+    Ribose.configure do |config|
+      config.api_token = ENV["RIBOSE_API_TOKEN"] || "RIBOSE_API_TOKEN"
+      config.user_email = ENV["RIBOSE_USER_EMAIL"] || "RIBOSE_USER_EMAIL"
     end
   end
 end

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -78,6 +78,15 @@ module Ribose
       )
     end
 
+    def stub_ribose_app_user_activate_api(attributes)
+      stub_api_response(
+        :post,
+        "signup.user",
+        data: { user: attributes },
+        filename: "user_activated",
+      )
+    end
+
     def stub_ribose_app_data_api
       stub_api_response(:get, "app_data", filename: "app_data")
     end
@@ -290,11 +299,14 @@ module Ribose
     end
 
     def ribose_auth_headers
-      {
-        "Accept" => "application/json",
-        "X-Indigo-Token" => Ribose.configuration.api_token,
-        "X-Indigo-Email" => Ribose.configuration.user_email,
-      }
+      Hash.new.tap do |headers|
+        headers["Accept"] = "application/json"
+
+        if Ribose.configuration.api_token
+          headers["X-Indigo-Token"] = Ribose.configuration.api_token
+          headers["X-Indigo-Email"] = Ribose.configuration.user_email
+        end
+      end
     end
 
     def response_with(filename:, status:)


### PR DESCRIPTION
In the previous commit, we have added the signup request sending out interface, and the next step is to activate that user account and that's when this commit comes in.

This commit adds the interface to activate the user account using the information user will receive through the Email.

This commit also modify some of the existing classes to allow a user to send a request without any authentication header in it

```ruby
  Ribose::User.activate(
    email: "user@example.com",
    password: "ASecureUserPassword",
    otp: "OTP Recived via the Email",
)
```

Closes: #45 