### PR TITLE
Add interface to delete a calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,12 @@ Ribose::Calendar.create(
 )
 ```
 
+#### Delete a calendar
+
+```ruby
+Ribose::Calendar.delete(calendar_id)
+```
+
 ### User
 
 #### Create a signup request

--- a/lib/ribose/calendar.rb
+++ b/lib/ribose/calendar.rb
@@ -4,6 +4,14 @@ module Ribose
     include Ribose::Actions::Fetch
     include Ribose::Actions::Create
 
+    def delete
+      Ribose::Request.delete(resource_path)
+    end
+
+    def self.delete(calendar_id)
+      new(resource_id: calendar_id).delete
+    end
+
     private
 
     def resource

--- a/spec/ribose/calendar_spec.rb
+++ b/spec/ribose/calendar_spec.rb
@@ -36,4 +36,15 @@ RSpec.describe Ribose::Calendar do
       expect(calendar.owner_type).to eq("User")
     end
   end
+
+  describe ".delete" do
+    it "removes a valid user calendar" do
+      calendar_id = 123_456_789
+      stub_ribose_calendar_delete_api(calendar_id)
+
+      expect do
+        Ribose::Calendar.delete(calendar_id)
+      end.not_to raise_error
+    end
+  end
 end

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -69,6 +69,12 @@ module Ribose
       )
     end
 
+    def stub_ribose_calendar_delete_api(calender_id)
+      stub_api_response(
+        :delete, "calendar/calendar/#{calender_id}", filename: "empty"
+      )
+    end
+
     def stub_ribose_app_user_create_api(attributes)
       stub_api_response(
         :post,


### PR DESCRIPTION
Ribose API offers `DELETE /calendar/calendar/:calendar_id` endpoint that allows us to delete a particular calendar and this commit use that endpoint and provides a ruby binding for that endpoint.

```ruby
Ribose::Calendar.delete(calendar_id)
```

Ref: #65 