### PR TITLE
Add interface to update a user space

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ Ribose::Space.create(
 )
 ```
 
+#### Update a user space
+
+```ruby
+Ribose::Space.update("space_uuid", name: "New updated name", **other_attributes)
+```
+
 #### Remove a user space
 
 To remove an existing space and we can use the following interface

--- a/lib/ribose/space.rb
+++ b/lib/ribose/space.rb
@@ -5,6 +5,7 @@ module Ribose
     include Ribose::Actions::All
     include Ribose::Actions::Fetch
     include Ribose::Actions::Create
+    include Ribose::Actions::Update
 
     def self.create(name:, **attributes)
       new(attributes.merge(name: name)).create

--- a/spec/ribose/space_spec.rb
+++ b/spec/ribose/space_spec.rb
@@ -36,6 +36,18 @@ RSpec.describe Ribose::Space do
     end
   end
 
+  describe ".update" do
+    it "updates a space with provided details" do
+      space_id = 123_456_789
+
+      stub_ribose_space_update_api(space_id, space_attributes)
+      space = Ribose::Space.update(space_id, space_attributes)
+
+      expect(space.id).not_to be_nil
+      expect(space.visibility).to eq("invisible")
+    end
+  end
+
   describe ".remove" do
     it "removes an existing space" do
       space_uuid = "8c63c209-8b98-41aa-a320-336462476ea1"

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -14,6 +14,12 @@ module Ribose
       )
     end
 
+    def stub_ribose_space_update_api(uuid, attributes)
+      stub_api_response(
+        :put, "spaces/#{uuid}", data: { space: attributes }, filename: "space"
+      )
+    end
+
     def stub_ribose_space_fetch_api(space_id)
       stub_api_response(:get, "spaces/#{space_id}", filename: "space")
     end


### PR DESCRIPTION
Ribose API has `PUT spaces/:space_uuid` endpoint and that supports to update an existing user space. This commit use that endpoint and adds the ruby binding to update a space using the client.

```ruby
Ribose::Space.update(
  "space_uuid",
  name: "New updated name",
  **other_attributes_hash,
)
```

Ref: #65