### PR TITLE
Interface to update a user settting

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ interface and it will return the details for that setting.
 Ribose::Setting.fetch(setting_id)
 ```
 
+#### Update a setting
+
+```ruby
+Ribose::Setting.update(setting_id, **new_updated_attributes_hash)
+```
+
 ### Spaces
 
 #### List user's spaces

--- a/lib/ribose/setting.rb
+++ b/lib/ribose/setting.rb
@@ -4,6 +4,7 @@ module Ribose
   class Setting < Ribose::Base
     include Ribose::Actions::All
     include Ribose::Actions::Fetch
+    include Ribose::Actions::Update
 
     private
 

--- a/spec/ribose/setting_spec.rb
+++ b/spec/ribose/setting_spec.rb
@@ -23,4 +23,18 @@ RSpec.describe Ribose::Setting do
       expect(setting.time_zone_detected).to eq("Asia/Bangkok")
     end
   end
+
+  describe ".update" do
+    it "updates a setting with provided details" do
+      new_theme_id = 6
+      setting_id = 123_456_789
+
+      stub_ribose_setting_update_api(setting_id, theme_id: new_theme_id)
+      setting = Ribose::Setting.update(setting_id, theme_id: new_theme_id)
+
+      expect(setting.id).to eq(setting_id)
+      expect(setting.type).to eq("Setting::Personal")
+      expect(setting.theme_id).to eq(new_theme_id.to_s)
+    end
+  end
 end

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -46,6 +46,15 @@ module Ribose
       stub_api_response(:get, "settings/#{id}", filename: "setting")
     end
 
+    def stub_ribose_setting_update_api(uuid, attributes)
+      stub_api_response(
+        :put,
+        "settings/#{uuid}",
+        data: { setting: attributes },
+        filename: "setting",
+      )
+    end
+
     def stub_ribose_stream_list_api
       stub_api_response(:get, "stream", filename: "stream")
     end


### PR DESCRIPTION
Ribose API has `PUT /settings/:setting_id` endpoint, which allows us to update user settings, and this commit utilize that endpoint and provide an interface for the API client. Usages.

```ruby
Ribose::Setting.update(setting_id, **new_updated_attributes_hash)
```

Reference: #65