### PR TITLE
Add Ribose flavored custom exceptions

### DIFF
--- a/lib/ribose.rb
+++ b/lib/ribose.rb
@@ -1,3 +1,6 @@
+require "faraday"
+require "sawyer"
+
 require "ribose/version"
 require "ribose/base"
 require "ribose/config"

--- a/lib/ribose/configuration.rb
+++ b/lib/ribose/configuration.rb
@@ -1,3 +1,5 @@
+require "ribose/response/raise_error"
+
 module Ribose
   class Configuration
     attr_accessor :api_host, :api_token, :user_email, :debug_mode
@@ -9,6 +11,12 @@ module Ribose
 
     def debug_mode?
       debug_mode == true
+    end
+
+    def add_default_middleware(builder)
+      builder.use(Ribose::Response::RaiseError)
+      builder.response(:logger, nil, bodies: true) if debug_mode?
+      builder.adapter(Faraday.default_adapter)
     end
   end
 end

--- a/lib/ribose/error.rb
+++ b/lib/ribose/error.rb
@@ -1,0 +1,30 @@
+module Ribose
+  class Error < StandardError
+    def initialize(response = nil)
+      @response = response
+      super
+    end
+
+    def self.from_response(response)
+      status = response[:status].to_i
+      if klass = case status
+                 when 400 then Ribose::BadRequest
+                 when 401 then Ribose::Unauthorized
+                 when 403 then Ribose::Forbidden
+                 when 404 then Ribose::NotFound
+                 when 422 then Ribose::UnprocessableEntity
+                 when 500..599 then Ribose::ServerError
+                 end
+
+        klass.new(response)
+      end
+    end
+  end
+
+  class BadRequest < Error; end
+  class Unauthorized < Error; end
+  class Forbidden < Error; end
+  class NotFound < Error; end
+  class UnprocessableEntity < Error; end
+  class ServerError < Error; end
+end

--- a/lib/ribose/file_uploader.rb
+++ b/lib/ribose/file_uploader.rb
@@ -86,12 +86,7 @@ module Ribose
       Faraday.new(upload_url) do |builder|
         builder.request :multipart
         builder.request :url_encoded
-
-        if Ribose.configuration.debug_mode?
-          builder.response :logger, nil, bodies: true
-        end
-
-        builder.adapter Faraday.default_adapter
+        Ribose.configuration.add_default_middleware(builder)
       end
     end
   end

--- a/lib/ribose/request.rb
+++ b/lib/ribose/request.rb
@@ -1,6 +1,3 @@
-require "faraday"
-require "sawyer"
-
 module Ribose
   class Request
     # Initialize a Request
@@ -94,16 +91,13 @@ module Ribose
     def sawyer_options
       {
         links_parser: Sawyer::LinkParsers::Simple.new,
-        faraday: Faraday.new(builder: custom_builder),
+        faraday: Faraday.new(builder: custom_rack_builder),
       }
     end
 
-    def custom_builder
-      if Ribose.configuration.debug_mode?
-        Faraday::RackBuilder.new do |builder|
-          builder.response :logger, nil, bodies: true
-          builder.adapter Faraday.default_adapter
-        end
+    def custom_rack_builder
+      Faraday::RackBuilder.new do |builder|
+        Ribose.configuration.add_default_middleware(builder)
       end
     end
 

--- a/lib/ribose/response/raise_error.rb
+++ b/lib/ribose/response/raise_error.rb
@@ -1,0 +1,15 @@
+require "ribose/error"
+
+module Ribose
+  module Response
+    class RaiseError < Faraday::Response::Middleware
+      private
+
+      def on_complete(response)
+        if error = Ribose::Error.from_response(response)
+          raise error
+        end
+      end
+    end
+  end
+end

--- a/spec/ribose/error_spec.rb
+++ b/spec/ribose/error_spec.rb
@@ -1,0 +1,67 @@
+require "spec_helper"
+
+RSpec.describe "Ribose Errors" do
+  context "when response is 200" do
+    it "does not raise any error" do
+      stub_ping_request_with(200)
+      expect { create_ping_request }.not_to raise_error
+    end
+  end
+
+  context "when response is 201" do
+    it "does not raise any error" do
+      stub_ping_request_with(201)
+      expect { create_ping_request }.not_to raise_error
+    end
+  end
+
+  context "when response is 400" do
+    it "retuns the bad request error" do
+      stub_ping_request_with(400)
+      expect { create_ping_request }.to raise_error(Ribose::BadRequest)
+    end
+  end
+
+  context "when response is 401" do
+    it "returns the unauthorized error" do
+      stub_ping_request_with(401)
+      expect { create_ping_request }.to raise_error(Ribose::Unauthorized)
+    end
+  end
+
+  context "when response is 403" do
+    it "returns the forbidden error" do
+      stub_ping_request_with(403)
+      expect { create_ping_request }.to raise_error(Ribose::Forbidden)
+    end
+  end
+
+  context "when response is 404" do
+    it "returns the not_found error" do
+      stub_ping_request_with(404)
+      expect { create_ping_request }.to raise_error(Ribose::NotFound)
+    end
+  end
+
+  context "when response is 422" do
+    it "returns unprocessable entity error" do
+      stub_ping_request_with(422)
+      expect { create_ping_request }.to raise_error(Ribose::UnprocessableEntity)
+    end
+  end
+
+  context "when the response is 5xx" do
+    it "returns server error" do
+      stub_ping_request_with(501)
+      expect { create_ping_request }.to raise_error(Ribose::ServerError)
+    end
+  end
+
+  def create_ping_request
+    Ribose::Request.get("/ping")
+  end
+
+  def stub_ping_request_with(status = 200, method = :get)
+    stub_api_response(method, "ping", filename: "ping", status: status)
+  end
+end


### PR DESCRIPTION
Currently for the invalid response, the API client does not raise any error but returns the response with the invalid status code.

This commit improves it a bit, and add the error handling middle ware that will check the response and ensures that we raise the correct error message based on the response.

Fixes #71 