### PR TITLE
Update interfaces to support client option

### DIFF
--- a/lib/ribose/actions/all.rb
+++ b/lib/ribose/actions/all.rb
@@ -35,8 +35,8 @@ module Ribose
         # @param options [Hash] Query parameters as Hash
         # @return [Array <Sawyer::Resource>]
         #
-        def all(options = {})
-          new.all(query: options)
+        def all(client: nil, **options)
+          new.all(client: client, query: options)
         end
       end
     end

--- a/lib/ribose/actions/create.rb
+++ b/lib/ribose/actions/create.rb
@@ -22,7 +22,7 @@ module Ribose
       end
 
       def request_body(attributes)
-        { resource_key.to_sym => validate(attributes) }
+        custom_option.merge(resource_key.to_sym => validate(attributes))
       end
 
       def create_resource

--- a/lib/ribose/actions/fetch.rb
+++ b/lib/ribose/actions/fetch.rb
@@ -13,7 +13,7 @@ module Ribose
       # @return [Sawyer::Resource]
       #
       def fetch
-        response = Request.get(resource_path)
+        response = Request.get(resource_path, custom_option)
         extract_resource(response) || response
       end
 
@@ -35,8 +35,8 @@ module Ribose
         # @param resource_id [String] The specific resource Id
         # @return [Sawyer::Resource]
         #
-        def fetch(resource_id)
-          new(resource_id: resource_id).fetch
+        def fetch(resource_id, options = {})
+          new(options.merge(resource_id: resource_id)).fetch
         end
       end
     end

--- a/lib/ribose/actions/update.rb
+++ b/lib/ribose/actions/update.rb
@@ -15,7 +15,9 @@ module Ribose
       private
 
       def update_resource
-        Ribose::Request.put(resource_path, resource_key.to_sym => attributes)
+        Ribose::Request.put(
+          resource_path, custom_option.merge(resource_key.to_sym => attributes)
+        )
       end
 
       module ClassMethods
@@ -24,7 +26,7 @@ module Ribose
         # @param resource_id [String] The Resource UUID
         # @param attributes [Hash] New attributes as Hash
         # @return [Sawyer::Resource] The Updated Resource
-        def update(resource_id, attributes)
+        def update(resource_id, attributes = {})
           new(attributes.merge(resource_id: resource_id)).update
         end
       end

--- a/lib/ribose/base.rb
+++ b/lib/ribose/base.rb
@@ -12,7 +12,18 @@ module Ribose
 
     private
 
-    attr_reader :resource_id, :attributes
+    attr_reader :resource_id, :attributes, :client
+
+    # User provided options
+    #
+    # Some of the API endpoints has support for custom options,
+    # for example sending a request as different client, pass
+    # some query parameters and etc, and that's where this will
+    # come in handy.
+    #
+    def custom_option
+      { client: client }
+    end
 
     # Extract Local Attributes
     #
@@ -29,6 +40,7 @@ module Ribose
     def extract_local_attributes; end
 
     def extract_base_attributes
+      @client = attributes.delete(:client)
       @resource_id = attributes.delete(:resource_id)
     end
   end

--- a/lib/ribose/calendar.rb
+++ b/lib/ribose/calendar.rb
@@ -5,11 +5,11 @@ module Ribose
     include Ribose::Actions::Create
 
     def delete
-      Ribose::Request.delete(resource_path)
+      Ribose::Request.delete(resource_path, custom_option)
     end
 
-    def self.delete(calendar_id)
-      new(resource_id: calendar_id).delete
+    def self.delete(calendar_id, attributes = {})
+      new(attributes.merge(resource_id: calendar_id)).delete
     end
 
     private

--- a/lib/ribose/connection.rb
+++ b/lib/ribose/connection.rb
@@ -21,8 +21,9 @@ module Ribose
     # @param options [Hash] Query parameters as a Hash
     # @return [Array <Sawyer::Resource>]
     #
-    def self.suggestions(options = {})
-      Request.get("people_finding", query: options).suggested_connection
+    def self.suggestions(client: nil, **options)
+      Request.get("people_finding", client: client, query: options).
+        suggested_connection
     end
 
     private

--- a/lib/ribose/connection_invitation.rb
+++ b/lib/ribose/connection_invitation.rb
@@ -8,20 +8,22 @@ module Ribose
       create_invitations[:invitations]
     end
 
-    def self.create(body:, emails:)
-      new(body: body, emails: emails).create
+    def self.create(body:, emails:, **attributes)
+      new(attributes.merge(body: body, emails: emails)).create
     end
 
-    def self.accept(invitation_id)
-      new(resource_id: invitation_id, state: 1).update
+    def self.accept(invitation_id, attributes = {})
+      new(attributes.merge(resource_id: invitation_id, state: 1)).update
     end
 
-    def self.reject(invitation_id)
-      new(resource_id: invitation_id, state: 2).update
+    def self.reject(invitation_id, attributes = {})
+      new(attributes.merge(resource_id: invitation_id, state: 2)).update
     end
 
-    def self.cancel(invitation_id)
-      Ribose::Request.delete("invitations/to_connection/#{invitation_id}")
+    def self.cancel(invitation_id, attributes = {})
+      Ribose::Request.delete(
+        "invitations/to_connection/#{invitation_id}", attributes
+      )
     end
 
     private
@@ -45,7 +47,9 @@ module Ribose
     def create_invitations
       Ribose::Request.post(
         [resources_path, "mass_create"].join("/"),
-        invitation: { body: attributes[:body], emails: attributes[:emails] },
+        custom_option.merge(
+          invitation: { body: attributes[:body], emails: attributes[:emails] }
+        )
       )
     end
   end

--- a/lib/ribose/conversation.rb
+++ b/lib/ribose/conversation.rb
@@ -4,7 +4,7 @@ module Ribose
     include Ribose::Actions::Create
 
     def remove
-      Ribose::Request.delete(resource_path)
+      Ribose::Request.delete(resource_path, custom_option)
     end
 
     # Listing Space Conversations
@@ -27,8 +27,8 @@ module Ribose
       new(attributes.merge(space_id: space_id)).create
     end
 
-    def self.remove(space_id:, conversation_id:)
-      new(space_id: space_id, conversation_id: conversation_id).remove
+    def self.remove(space_id:, conversation_id:, **option)
+      new(space_id: space_id, conversation_id: conversation_id, **option).remove
     end
 
     private

--- a/lib/ribose/join_space_request.rb
+++ b/lib/ribose/join_space_request.rb
@@ -4,12 +4,12 @@ module Ribose
     include Ribose::Actions::Create
     include Ribose::Actions::Update
 
-    def self.accept(invitation_id)
-      new(resource_id: invitation_id, state: 1).update
+    def self.accept(invitation_id, options = {})
+      new(resource_id: invitation_id, state: 1, **options).update
     end
 
-    def self.reject(invitation_id)
-      new(resource_id: invitation_id, state: 2).update
+    def self.reject(invitation_id, options = {})
+      new(resource_id: invitation_id, state: 2, **options).update
     end
 
     def self.update(invitation_id, attributes)

--- a/lib/ribose/message.rb
+++ b/lib/ribose/message.rb
@@ -21,7 +21,7 @@ module Ribose
     end
 
     def remove
-      Ribose::Request.delete(resource_path)
+      Ribose::Request.delete(resource_path, custom_option)
     end
 
     # Listing Conversation Messages
@@ -65,8 +65,8 @@ module Ribose
     # @param conversation_id [String] The Conversation UUID
     # @return [Sawyer::Resource]
     #
-    def self.remove(space_id:, message_id:, conversation_id:)
-      new(space_id, conversation_id, message_id: message_id).remove
+    def self.remove(space_id:, message_id:, conversation_id:, **options)
+      new(space_id, conversation_id, message_id: message_id, **options).remove
     end
 
     private
@@ -76,6 +76,10 @@ module Ribose
 
     def resource
       "message"
+    end
+
+    def custom_option
+      {}
     end
 
     def validate(attributes)

--- a/lib/ribose/space_invitation.rb
+++ b/lib/ribose/space_invitation.rb
@@ -8,30 +8,32 @@ module Ribose
       create_invitations[:invitations]
     end
 
-    def self.mass_create(space_id, attributes)
+    def self.mass_create(space_id, attributes = {})
       new(attributes.merge(space_id: space_id)).mass_create
     end
 
-    def self.update(invitation_id, attributes)
+    def self.update(invitation_id, attributes = {})
       new(attributes.merge(resource_id: invitation_id)).update
     end
 
-    def self.accept(invitation_id)
+    def self.accept(invitation_id, attributes = {})
       new(resource_id: invitation_id, state: 1).update
     end
 
-    def self.resend(invitation_id)
+    def self.resend(invitation_id, attributes = {})
       Ribose::Request.post(
-        "/invitations/to_new_member/#{invitation_id}/resend", {}
+        "/invitations/to_new_member/#{invitation_id}/resend", attributes
       )
     end
 
-    def self.reject(invitation_id)
-      new(resource_id: invitation_id, state: 2).update
+    def self.reject(invitation_id, attributes = {})
+      new(attributes.merge(resource_id: invitation_id, state: 2)).update
     end
 
-    def self.cancel(invitation_id)
-      Ribose::Request.delete(["invitations/to_space", invitation_id].join("/"))
+    def self.cancel(invitation_id, attributes = {})
+      Ribose::Request.delete(
+        ["invitations/to_space", invitation_id].join("/"), attributes
+      )
     end
 
     private
@@ -57,7 +59,9 @@ module Ribose
     end
 
     def create_invitations
-      Ribose::Request.post(mass_create_path, invitation: attributes)
+      Ribose::Request.post(
+        mass_create_path, custom_option.merge(invitation: attributes)
+      )
     end
 
     def mass_create_path

--- a/lib/ribose/user.rb
+++ b/lib/ribose/user.rb
@@ -7,7 +7,10 @@ module Ribose
     end
 
     def activate
-      Ribose::Request.post("signup.user", user: attributes, auth_header: false)
+      Ribose::Request.post(
+        "signup.user",
+        custom_option.merge(user: attributes, auth_header: false),
+      )
     end
 
     # Activate a user


### PR DESCRIPTION
Recently, we have added support for multiple clients using the same application environment, but the idea here is to keep a client as a primary client that will be used for all of the requests and then also to have a `:client` option support that will allow user to provide a custom one when necessary.

This commit adds this functionality so we can easily switch between multiple clients and send the underlying request, To provide a custom client any with the interface we can use:

```ruby
client_two = Ribose::Client.new(**client_two_info)
Ribose::ConnectionInvitation.accept(invitation_id, client: client_two)
```

Related: #46 