### PR TITLE
Instantiate a client using login credentials

### DIFF
--- a/lib/ribose/client.rb
+++ b/lib/ribose/client.rb
@@ -7,6 +7,21 @@ module Ribose
       @user_email = options.fetch(:email, configuration.user_email).to_s
     end
 
+    # Initiate a ribose client
+    #
+    # This interface takes email and password and then it will
+    # do all the underlying work to find out the authentication
+    # token and retrun a ribose client.
+    #
+    # @param :email [String] The email for your Ribose account
+    # @param :password [String] The password for your account
+    # @return [Ribose::Client] A new client with your details
+    #
+    def self.from_login(email:, password:)
+      session = Session.create(username: email, password: password)
+      new(email: email, token: session["authentication_token"])
+    end
+
     private
 
     def configuration

--- a/spec/ribose/client_spec.rb
+++ b/spec/ribose/client_spec.rb
@@ -20,4 +20,29 @@ RSpec.describe Ribose::Client do
       end
     end
   end
+
+  describe ".from_login" do
+    it "authenticate the user and build a client" do
+      email = "useremail@example..com"
+      password = "supersecretpassword"
+
+      allow(Ribose::Session).to receive(:create).and_return(session_hash)
+      client = Ribose::Client.from_login(email: email, password: password)
+
+      expect(client.user_email).to eq(email)
+      expect(client.api_token).to eq(session_hash["authentication_token"])
+    end
+  end
+
+  def session_hash
+    {
+      "authentication_token" => "SecretToken",
+      "last_activity" => {
+        "id" => 122072207,
+        "session_id" => "SessionId",
+        "browser" => "Ribose Ruby Client",
+        "user_id" => "user-uuid-123-4567"
+      },
+    }
+  end
 end


### PR DESCRIPTION
The Ribose API identify a user using the `api_token` and `email`, but this requires us to do some extra work to find out and set the details properly.

This commit  enhance this process a bit, from now on user can also use the `Ribose::Client.from_login` interface and provide their login details and the client will authenticate and set their details properly.

```ruby
client = Ribose::Client.from_login(email:, password:)
Ribose::Space.all(client: client)
```

Related: PR #46