### PR TITLE
Interface to update a conversation

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,12 @@ Ribose::Conversation.create(
 )
 ```
 
+#### Update a conversation
+
+```ruby
+Ribose::Conversation.update(space_id, conversation_id, new_attributes_hash)
+```
+
 #### Remove A Conversation
 
 ```ruby

--- a/lib/ribose/conversation.rb
+++ b/lib/ribose/conversation.rb
@@ -3,6 +3,7 @@ module Ribose
     include Ribose::Actions::All
     include Ribose::Actions::Fetch
     include Ribose::Actions::Create
+    include Ribose::Actions::Update
 
     def remove
       Ribose::Request.delete(resource_path, custom_option)
@@ -23,6 +24,7 @@ module Ribose
     # @param space_id [String] The Space UUID
     # @param conversation_id [String] Conversation UUID
     # @param options [Hash] Query parameters as a Hash
+    # @return [Sawyer::Resource] The conversation
     #
     def self.fetch(space_id, conversation_id, options = {})
       new(space_id: space_id, conversation_id: conversation_id, **options).fetch
@@ -36,6 +38,21 @@ module Ribose
     #
     def self.create(space_id, attributes)
       new(attributes.merge(space_id: space_id)).create
+    end
+
+    # Update a conversation
+    #
+    # @param space_id [String] The Space UUID
+    # @param conversation_id [String] Conversation UUID
+    # @param attributes [Hash] Query parameters as a Hash
+    # @return [Sawyer::Resource] The updated conversation
+    #
+    def self.update(space_id, conversation_id, attributes = {})
+      new(
+        space_id: space_id,
+        conversation_id: conversation_id,
+        **attributes,
+      ).update
     end
 
     def self.remove(space_id:, conversation_id:, **option)

--- a/spec/fixtures/conversation.json
+++ b/spec/fixtures/conversation.json
@@ -1,24 +1,26 @@
 {
-  "id": "456789",
-  "space_id": "123456789",
-  "created_at": "2017-02-13 14:15:45 +0000",
-  "updated_at": "2017-02-13 14:15:45 +0000",
-  "name": "Trips to the Mars!",
-  "tag_list": [],
-  "published": false,
-  "is_favorite": false,
-  "is_read": true,
-  "allow_publish": false,
-  "number_of_messages": 1,
-  "allow_edit": false,
-  "allow_delete": false,
-  "allow_comment": true,
-  "contents": "Did you already book the tickets?",
-  "attachments_listed": [],
-  "user": {
-    "id": "1u022072720722",
-    "name": "John Doe",
-    "connected": true,
-    "mutual_spaces": [ "3y939397393373703", "94744044074897474" ]
+  "conversation": {
+    "id": "456789",
+    "space_id": "123456789",
+    "created_at": "2017-02-13 14:15:45 +0000",
+    "updated_at": "2017-02-13 14:15:45 +0000",
+    "name": "Trips to the Mars!",
+    "tag_list": [],
+    "published": false,
+    "is_favorite": false,
+    "is_read": true,
+    "allow_publish": false,
+    "number_of_messages": 1,
+    "allow_edit": false,
+    "allow_delete": false,
+    "allow_comment": true,
+    "contents": "Did you already book the tickets?",
+    "attachments_listed": [],
+    "user": {
+      "id": "1u022072720722",
+      "name": "John Doe",
+      "connected": true,
+      "mutual_spaces": [ "3y939397393373703", "94744044074897474" ]
+    }
   }
 }

--- a/spec/ribose/conversation_spec.rb
+++ b/spec/ribose/conversation_spec.rb
@@ -41,6 +41,24 @@ RSpec.describe Ribose::Conversation do
     end
   end
 
+  describe ".update" do
+    it "updates a conversation with provided details" do
+      space_id = 123_456_789
+      conversation_id = 456_789
+
+      stub_ribose_space_conversation_update_api(
+        space_id, conversation_id, conversation_attrs
+      )
+
+      conversation = Ribose::Conversation.update(
+        space_id, conversation_id, conversation_attrs
+      )
+
+      expect(conversation.id).not_to be_nil
+      expect(conversation.contents).to eq("Did you already book the tickets?")
+    end
+  end
+
   describe ".remove" do
     it "remvoes a conversation from a space" do
       space_id = 123456789

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -140,6 +140,17 @@ module Ribose
       )
     end
 
+    def stub_ribose_space_conversation_update_api(sid, cid, attributes)
+      attributes.delete(:space_id)
+
+      stub_api_response(
+        :put,
+        [conversations_path(sid), cid].join("/"),
+        data: { conversation: attributes },
+        filename: "conversation",
+      )
+    end
+
     def stub_ribose_space_conversation_remove(space_id, conversation_id)
       path = [conversations_path(space_id), conversation_id].join("/")
       stub_api_response(:delete, path, filename: "empty", status: 200)


### PR DESCRIPTION
Ribose API offers `PUT /conversation/:id` endpoint which allows us to update any of the existing conversation, and this commit usages that endpoint and provides a ruby binding for that. Usages:

```ruby
Ribose::Conversation.update(
  space_id, conversation_id, new_attributes_hash
)
```

Related: PR #65