### PR TITLE
Update interface to destroy conversation

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Ribose::Conversation.update(space_id, conversation_id, new_attributes_hash)
 #### Remove A Conversation
 
 ```ruby
-Ribose::Conversation.remove(space_id: "space_id", conversation_id: "12345")
+Ribose::Conversation.destroy(space_id: "space_id", conversation_id: "12345")
 ```
 
 ### Message

--- a/lib/ribose/conversation.rb
+++ b/lib/ribose/conversation.rb
@@ -5,7 +5,7 @@ module Ribose
     include Ribose::Actions::Create
     include Ribose::Actions::Update
 
-    def remove
+    def destroy
       Ribose::Request.delete(resource_path, custom_option)
     end
 
@@ -55,8 +55,18 @@ module Ribose
       ).update
     end
 
-    def self.remove(space_id:, conversation_id:, **option)
-      new(space_id: space_id, conversation_id: conversation_id, **option).remove
+    # Remove a conversation
+    #
+    # @param space_id [String] The Space UUID
+    # @param conversation_id [String] Conversation UUID
+    # @param options [Hash] Query parameters as a Hash
+    #
+    def self.destroy(space_id:, conversation_id:, **options)
+      new(
+        space_id: space_id,
+        conversation_id: conversation_id,
+        **options,
+      ).destroy
     end
 
     private

--- a/spec/ribose/conversation_spec.rb
+++ b/spec/ribose/conversation_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Ribose::Conversation do
     end
   end
 
-  describe ".remove" do
+  describe ".destroy" do
     it "remvoes a conversation from a space" do
       space_id = 123456789
       conversation_id = 987_654_321
@@ -67,8 +67,9 @@ RSpec.describe Ribose::Conversation do
       stub_ribose_space_conversation_remove(space_id, conversation_id)
 
       expect do
-        Ribose::Conversation.
-          remove(space_id: space_id, conversation_id: conversation_id)
+        Ribose::Conversation.destroy(
+          space_id: space_id, conversation_id: conversation_id,
+        )
       end.not_to raise_error
     end
   end


### PR DESCRIPTION
Currently, we are using `remove` interface to remove a conversation, but most of the places we planned to call in a `destory`, so to keep the consistency, this commit updates the existing interface.

Related: PR #65