### PR TITLE
Interface to fetch current user profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ interface
 Ribose::AppRelation.fetch(app_relation_id)
 ```
 
+### Profile
+
+#### Fetch user profile
+
+```ruby
+Ribose::Profile.fetch
+```
+
 ### Settings
 
 #### List user's settings

--- a/lib/ribose.rb
+++ b/lib/ribose.rb
@@ -25,6 +25,7 @@ require "ribose/join_space_request"
 require "ribose/connection_invitation"
 require "ribose/user"
 require "ribose/session"
+require "ribose/profile"
 
 module Ribose
   def self.root

--- a/lib/ribose/profile.rb
+++ b/lib/ribose/profile.rb
@@ -1,0 +1,19 @@
+module Ribose
+  class Profile < Ribose::Base
+    include Ribose::Actions::Fetch
+
+    def self.fetch(options = {})
+      new(resource_id: nil, **options).fetch
+    end
+
+    private
+
+    def resource
+      "user"
+    end
+
+    def resources_path
+      "people/profile"
+    end
+  end
+end

--- a/spec/fixtures/profile.json
+++ b/spec/fixtures/profile.json
@@ -1,0 +1,10 @@
+{
+  "user": {
+    "id": 12345,
+    "first_name": "John",
+    "last_name": "Doe",
+    "user_id": "63116bd1-c0848",
+    "fields": {},
+    "name": "John Doe"
+  }
+}

--- a/spec/ribose/profile_spec.rb
+++ b/spec/ribose/profile_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+
+RSpec.describe Ribose::Profile do
+  describe ".fetch" do
+    it "retrieves the current user profile" do
+      stub_ribose_fetch_profile_api
+      profile = Ribose::Profile.fetch
+
+      expect(profile.id).not_to be_nil
+      expect(profile.first_name).to eq("John")
+      expect(profile.name).to eq("John Doe")
+    end
+  end
+end

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -314,6 +314,10 @@ module Ribose
       )
     end
 
+    def stub_ribose_fetch_profile_api
+      stub_api_response(:get, "people/profile/", filename: "profile")
+    end
+
     private
 
     def ribose_endpoint(endpoint)


### PR DESCRIPTION
Ribose API offers `GET /people/profile` endpoint which returns the details of currently configured users, this commit usages this endpoint and provides a ruby binding for that.

```ruby
Ribose::Profile.fetch
```