### PR TITLE
Interface to update current user profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ Ribose::AppRelation.fetch(app_relation_id)
 Ribose::Profile.fetch
 ```
 
+#### Update user profile
+
+```ruby
+Ribose::Profile.update(first_name: "John", last_name: "Doe")
+```
+
 ### Settings
 
 #### List user's settings

--- a/lib/ribose/profile.rb
+++ b/lib/ribose/profile.rb
@@ -1,9 +1,24 @@
 module Ribose
   class Profile < Ribose::Base
     include Ribose::Actions::Fetch
+    include Ribose::Actions::Update
 
+    # Fetch user profile
+    #
+    # @param options [Hash] The query parameters
+    # @return [Sawyer::Resource] The user profile
+    #
     def self.fetch(options = {})
       new(resource_id: nil, **options).fetch
+    end
+
+    # Update user profile
+    #
+    # @param attributes [Hash] The new attributes
+    # @return [Sawyer::Resource] The user profile
+    #
+    def self.update(attributes)
+      new(resource_id: nil, **attributes).update
     end
 
     private

--- a/spec/ribose/profile_spec.rb
+++ b/spec/ribose/profile_spec.rb
@@ -11,4 +11,16 @@ RSpec.describe Ribose::Profile do
       expect(profile.name).to eq("John Doe")
     end
   end
+
+  describe ".updates" do
+    it "updates teh current user profile" do
+      attributes = { frest_name: "John", last_name: "Doe" }
+
+      stub_ribose_update_profile_api(attributes)
+      profile = Ribose::Profile.update(attributes)
+
+      expect(profile.id).not_to be_nil
+      expect(profile.name).to eq("John Doe")
+    end
+  end
 end

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -318,6 +318,12 @@ module Ribose
       stub_api_response(:get, "people/profile/", filename: "profile")
     end
 
+    def stub_ribose_update_profile_api(attributes)
+      stub_api_response(
+        :put, "people/profile/", data: { user: attributes }, filename: "profile"
+      )
+    end
+
     private
 
     def ribose_endpoint(endpoint)


### PR DESCRIPTION
The Ribose API offers `PUT /people/profile` endpoints that allow use to update the profile for the currently configured users, and this commit adds the ruby binding so we can easily do that using the client now. Usage

```ruby
Ribose::Profile.update(first_name: "John", last_name: "Doe")
```