### PR TITLE
Add interface to set user login name

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ Ribose::Profile.fetch
 Ribose::Profile.update(first_name: "John", last_name: "Doe")
 ```
 
+#### Set user login
+
+```ruby
+Ribose::Profile.set_login(login_name)
+```
+
 ### Settings
 
 #### List user's settings

--- a/lib/ribose/profile.rb
+++ b/lib/ribose/profile.rb
@@ -3,6 +3,10 @@ module Ribose
     include Ribose::Actions::Fetch
     include Ribose::Actions::Update
 
+    def set_login
+      update_login_name[resource_key]
+    end
+
     # Fetch user profile
     #
     # @param options [Hash] The query parameters
@@ -21,6 +25,15 @@ module Ribose
       new(resource_id: nil, **attributes).update
     end
 
+    # Set login name
+    #
+    # @param login [String] The user login name
+    # @return [Sawyer::Resource] The user profile
+    #
+    def self.set_login(name, options = {})
+      new(login: name, **options).set_login
+    end
+
     private
 
     def resource
@@ -29,6 +42,13 @@ module Ribose
 
     def resources_path
       "people/profile"
+    end
+
+    def update_login_name
+      Ribose::Request.put(
+        "people/users/#{fetch.user_id}",
+        resource_key.to_sym => { login: attributes[:login] },
+      )
     end
   end
 end

--- a/spec/fixtures/profile.json
+++ b/spec/fixtures/profile.json
@@ -3,7 +3,7 @@
     "id": 12345,
     "first_name": "John",
     "last_name": "Doe",
-    "user_id": "63116bd1-c0848",
+    "user_id": "63116bd1",
     "fields": {},
     "name": "John Doe"
   }

--- a/spec/ribose/profile_spec.rb
+++ b/spec/ribose/profile_spec.rb
@@ -23,4 +23,18 @@ RSpec.describe Ribose::Profile do
       expect(profile.name).to eq("John Doe")
     end
   end
+
+  describe ".set_login" do
+    it "sets the login for the current user" do
+      user_id = "63116bd1"
+      login = "new_login_name"
+
+      stub_ribose_fetch_profile_api
+      stub_ribose_set_login_name_api(user_id, login)
+      profile = Ribose::Profile.set_login(login)
+
+      expect(profile.id).not_to be_nil
+      expect(profile.name).to eq("John Doe")
+    end
+  end
 end

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -324,6 +324,15 @@ module Ribose
       )
     end
 
+    def stub_ribose_set_login_name_api(user_id, name)
+      stub_api_response(
+        :put,
+        "people/users/#{user_id}",
+        data: { user: { login: name } },
+        filename: "profile",
+      )
+    end
+
     private
 
     def ribose_endpoint(endpoint)


### PR DESCRIPTION
Ribose API offers `POST /profile/users/:user_id` which allows us to set the login name for the current user, and this commit usage this endpoint and provides a ruby binding for that.

```ruby
Ribose::Profile.set_login(login_name)
```