### PR TITLE
Extract out the delete action to module

### DIFF
--- a/lib/ribose/actions.rb
+++ b/lib/ribose/actions.rb
@@ -2,6 +2,7 @@ require "ribose/actions/all"
 require "ribose/actions/fetch"
 require "ribose/actions/create"
 require "ribose/actions/update"
+require "ribose/actions/delete"
 
 module Ribose
   module Actions

--- a/lib/ribose/actions/delete.rb
+++ b/lib/ribose/actions/delete.rb
@@ -1,0 +1,32 @@
+require "ribose/actions/base"
+
+module Ribose
+  module Actions
+    module Delete
+      extend Ribose::Actions::Base
+
+      def delete
+        Ribose::Request.delete(resource_path, custom_option)
+      end
+
+      module ClassMethods
+        # Delete a resource
+        #
+        # @param resource_id [String] Resource UUID
+        # @param options [Hash] Query parameters as Hash
+        #
+        def delete(resource_id, options = {})
+          new(resource_id: resource_id, **options).delete
+        end
+
+        # Aliases for delete
+        #
+        # There is another variation `cancel` that we have been using in
+        # some resources inter exchangbly, so let's keep that legacy support
+        # for now and we can decide about those in the future.
+        #
+        alias_method :cancel, :delete
+      end
+    end
+  end
+end

--- a/lib/ribose/calendar.rb
+++ b/lib/ribose/calendar.rb
@@ -3,14 +3,7 @@ module Ribose
     include Ribose::Actions::All
     include Ribose::Actions::Fetch
     include Ribose::Actions::Create
-
-    def delete
-      Ribose::Request.delete(resource_path, custom_option)
-    end
-
-    def self.delete(calendar_id, attributes = {})
-      new(attributes.merge(resource_id: calendar_id)).delete
-    end
+    include Ribose::Actions::Delete
 
     private
 

--- a/lib/ribose/connection_invitation.rb
+++ b/lib/ribose/connection_invitation.rb
@@ -3,6 +3,7 @@ module Ribose
     include Ribose::Actions::All
     include Ribose::Actions::Fetch
     include Ribose::Actions::Update
+    include Ribose::Actions::Delete
 
     def create
       create_invitations[:invitations]
@@ -18,12 +19,6 @@ module Ribose
 
     def self.reject(invitation_id, attributes = {})
       new(attributes.merge(resource_id: invitation_id, state: 2)).update
-    end
-
-    def self.cancel(invitation_id, attributes = {})
-      Ribose::Request.delete(
-        "invitations/to_connection/#{invitation_id}", attributes
-      )
     end
 
     private

--- a/lib/ribose/conversation.rb
+++ b/lib/ribose/conversation.rb
@@ -4,10 +4,7 @@ module Ribose
     include Ribose::Actions::Fetch
     include Ribose::Actions::Create
     include Ribose::Actions::Update
-
-    def destroy
-      Ribose::Request.delete(resource_path, custom_option)
-    end
+    include Ribose::Actions::Delete
 
     # Listing Space Conversations
     #
@@ -61,12 +58,8 @@ module Ribose
     # @param conversation_id [String] Conversation UUID
     # @param options [Hash] Query parameters as a Hash
     #
-    def self.destroy(space_id:, conversation_id:, **options)
-      new(
-        space_id: space_id,
-        conversation_id: conversation_id,
-        **options,
-      ).destroy
+    def self.destroy(space_id:, conversation_id:, **opts)
+      new(space_id: space_id, conversation_id: conversation_id, **opts).delete
     end
 
     private

--- a/lib/ribose/message.rb
+++ b/lib/ribose/message.rb
@@ -5,6 +5,7 @@ module Ribose
     include Ribose::Actions::All
     include Ribose::Actions::Create
     include Ribose::Actions::Update
+    include Ribose::Actions::Delete
 
     # Message initilaiztion
     #
@@ -18,10 +19,6 @@ module Ribose
       @attributes = attributes
       @conversation_id = conversation_id
       @message_id = attributes.delete(:message_id)
-    end
-
-    def remove
-      Ribose::Request.delete(resource_path, custom_option)
     end
 
     # Listing Conversation Messages
@@ -66,7 +63,7 @@ module Ribose
     # @return [Sawyer::Resource]
     #
     def self.remove(space_id:, message_id:, conversation_id:, **options)
-      new(space_id, conversation_id, message_id: message_id, **options).remove
+      new(space_id, conversation_id, message_id: message_id, **options).delete
     end
 
     private

--- a/lib/ribose/space_invitation.rb
+++ b/lib/ribose/space_invitation.rb
@@ -3,6 +3,7 @@ module Ribose
     include Ribose::Actions::All
     include Ribose::Actions::Create
     include Ribose::Actions::Update
+    include Ribose::Actions::Delete
 
     def mass_create
       create_invitations[:invitations]
@@ -31,9 +32,7 @@ module Ribose
     end
 
     def self.cancel(invitation_id, attributes = {})
-      Ribose::Request.delete(
-        ["invitations/to_space", invitation_id].join("/"), attributes
-      )
+      new(resource_id: invitation_id, **attributes).delete
     end
 
     private

--- a/spec/ribose/actions/delete_spec.rb
+++ b/spec/ribose/actions/delete_spec.rb
@@ -1,0 +1,24 @@
+require "spec_helper"
+
+RSpec.describe "TestDeleteAction" do
+  describe ".delete" do
+    it "removes a specific resource" do
+      resource_id = 123_456_789
+      stub_ribose_calendar_delete_api(resource_id)
+
+      expect { Ribose::TestDeleteAction.delete(resource_id) }.not_to raise_error
+    end
+  end
+
+  module Ribose
+    class TestDeleteAction < Ribose::Base
+      include Ribose::Actions::Delete
+
+      private
+
+      def resources_path
+        "calendar/calendar"
+      end
+    end
+  end
+end


### PR DESCRIPTION
In the current codebase, there are couple of interfaces that have been re-implementing delete again and again, which is bit of redundant and it also has a sister concern `cancel`.

In the long term we should probably stick to one, but for now let's extract that out to a separate module and also sets the `cancel` as an alias.