### PR TITLE
Add interface to list space wiki pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,6 +527,14 @@ Ribose::User.activate(
 )
 ```
 
+### Wikis
+
+#### List wiki pages
+
+```ruby
+Ribose::Wiki.all(space_id, options = {})
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/ribose.rb
+++ b/lib/ribose.rb
@@ -26,6 +26,7 @@ require "ribose/connection_invitation"
 require "ribose/user"
 require "ribose/session"
 require "ribose/profile"
+require "ribose/wiki"
 
 module Ribose
   def self.root

--- a/lib/ribose/wiki.rb
+++ b/lib/ribose/wiki.rb
@@ -1,0 +1,25 @@
+module Ribose
+  class Wiki < Ribose::Base
+    include Ribose::Actions::All
+
+    def self.all(space_id, options = {})
+      new(space_id: space_id, **options).all
+    end
+
+    private
+
+    attr_reader :space_id
+
+    def resource
+      "wiki_page"
+    end
+
+    def extract_local_attributes
+      @space_id = attributes.delete(:space_id)
+    end
+
+    def resources_path
+      ["spaces", space_id, "wiki", "wiki_pages"].join("/")
+    end
+  end
+end

--- a/spec/fixtures/wikis.json
+++ b/spec/fixtures/wikis.json
@@ -1,0 +1,197 @@
+{
+  "wiki_pages": [
+    {
+      "id": 12345,
+      "name": "Wiki Page One",
+      "address": "wiki-page-one",
+      "created_at": "2017-11-08T07:33:25.000+00:00",
+      "updated_at": "2017-11-08T07:33:25.000+00:00",
+      "version": 1,
+      "allow_attachments": true,
+      "allow_comments": true,
+      "revision": 23,
+      "tag_list": [
+        "wiki",
+        "init"
+      ],
+      "space_id": 123456,
+      "attachments_listed": [],
+      "author_ids": [
+        "2970d105-5ccc"
+      ],
+      "is_new_record": false,
+      "rendered_created_by": "2970d105-5cc",
+      "rendered_updated_by": "2970d105-5ccc",
+      "allow_create": true,
+      "allow_edit": true,
+      "allow_update": true,
+      "allow_delete": true,
+      "allow_comment": true,
+      "allow_manage_permissions": true,
+      "history": {
+        "current_ver": 1,
+        "versions": [
+          {
+            "id": 1,
+            "updater_id": "2970d105-5ccc",
+            "updated_at": "2017-11-08T07:33:25.000+00:00"
+          }
+        ]
+      },
+      "current_user": "2970d105-5ccc",
+      "related_users": {
+        "2970d105-5ccc": {
+          "id": "2970d105-5ccc",
+          "name": "John Doe",
+          "connected": true,
+          "mutual_spaces": [
+            "2970d105-5ccc111",
+            "2970d105-5ccc111133"
+          ]
+        }
+      },
+      "encoded_rendered_content": "This%26nbsp%3Bis%26nbsp%3Bthe%26nbsp%3Bfirst%26nbsp%3Bwiki%26nbsp%3Bpage%26nbsp%3Bfor%26nbsp%3BRibose!Hello%2C%26nbsp%3B",
+      "comments": [],
+      "user": {
+        "id": "2970d105-5ccc",
+        "name": "John Doe",
+        "connected": true,
+        "mutual_spaces": [
+          "a7f7b94e-a007-4457",
+          "a45387e2-a573-48ba"
+        ]
+      },
+      "updater": {
+        "id": "2970d105-5ccc",
+        "name": "John Doe",
+        "connected": true,
+        "mutual_spaces": [
+          "a7f7b94e-a007-4457-868f",
+          "a45387e2-a573-48ba-8df",
+          "268b0407-c3a3-4aad-8693",
+          "52e47e18-9a9d-4663-94c5"
+        ]
+      }
+    },
+    {
+      "id": 456789,
+      "name": "Wiki Page Two",
+      "address": "page-two",
+      "created_at": "2017-11-08T07:34:23.000+00:00",
+      "updated_at": "2017-11-08T07:34:23.000+00:00",
+      "version": 1,
+      "allow_attachments": true,
+      "allow_comments": true,
+      "revision": 13,
+      "tag_list": [
+        "second-page",
+        "wiki"
+      ],
+      "space_id": "2970d105-5ccc",
+      "attachments_listed": [],
+      "author_ids": [
+        "2970d105-5ccc"
+      ],
+      "is_new_record": false,
+      "rendered_created_by": "2970d105-5ccc",
+      "rendered_updated_by": "2970d105-5ccc",
+      "allow_create": true,
+      "allow_edit": true,
+      "allow_update": true,
+      "allow_delete": true,
+      "allow_comment": true,
+      "allow_manage_permissions": true,
+      "history": {
+        "current_ver": 1,
+        "versions": [
+          {
+            "id": 1,
+            "updater_id": "2970d105-5ccc",
+            "updated_at": "2017-11-08T07:34:23.000+00:00"
+          }
+        ]
+      },
+      "current_user": "2970d105-5ccc",
+      "related_users": {
+        "2970d105-5ccc-4a8c-b0c4-ec32d539a00a": {
+          "id": "2970d105-5ccc",
+          "name": "John Doe",
+          "connected": true,
+          "mutual_spaces": [
+            "a7f7b94e-a007--",
+            "a45387e2-a573-",
+            "268b0407-c3a3-",
+            "52e47e18-9a9d-"
+          ]
+        }
+      },
+      "encoded_rendered_content": "This%26nbsp%3Bis%26nbsp%3Bthe%26nbsp%3Bsecond%26nbsp%3Bpage%26nbsp%3Bfor%26nbsp%3Bthe%26nbsp%3BWiki",
+      "comments": [],
+      "user": {
+        "id": "2970d105-5ccc",
+        "name": "John Doe",
+        "connected": true,
+        "mutual_spaces": [
+          "a7f7b94e-a007-4457-",
+          "a45387e2-a573-48ba-",
+          "268b0407-c3a3-4aad-",
+          "52e47e18-9a9d-4663-"
+        ]
+      },
+      "updater": {
+        "id": "2970d105-5ccc",
+        "name": "John Doe",
+        "connected": true,
+        "mutual_spaces": [
+          "a7f7b94e-a007-4457-5af319706ad5",
+          "a45387e2-a573-48ba-f1424d8a8ec9",
+          "268b0407-c3a3-4aad-fdba789f7f0d",
+          "52e47e18-9a9d-4663-abcb18fa783a"
+        ]
+      }
+    }
+  ],
+  "tags": {
+    "selected_tags": [],
+    "related_tags": [
+      "wiki",
+      "init",
+      "second-page"
+    ],
+    "all_tags": [
+      {
+        "name": "wiki",
+        "count": 2,
+        "height": 3
+      },
+      {
+        "name": "init",
+        "count": 1,
+        "height": 2
+      },
+      {
+        "name": "second-page",
+        "count": 1,
+        "height": 2
+      }
+    ]
+  },
+  "allow_create": true,
+  "recent_activity": [
+    {
+      "date": "Wednesday, November 08, 2017",
+      "links": [
+        {
+          "id": 7679,
+          "name": "Page two",
+          "path": "page-two"
+        },
+        {
+          "id": 7678,
+          "name": "Wiki Page One",
+          "path": "wiki-page-one"
+        }
+      ]
+    }
+  ]
+}

--- a/spec/ribose/wiki_spec.rb
+++ b/spec/ribose/wiki_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+RSpec.describe Ribose::Wiki do
+  describe ".all" do
+    it "retrieves the list of wiki pages" do
+      space_id = 123_456
+
+      stub_ribose_wiki_list_api(space_id)
+      wikis = Ribose::Wiki.all(space_id)
+
+      expect(wikis.count).to eq(2)
+      expect(wikis.first.name).to eq("Wiki Page One")
+      expect(wikis.last.name).to eq("Wiki Page Two")
+    end
+  end
+end

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -333,6 +333,12 @@ module Ribose
       )
     end
 
+    def stub_ribose_wiki_list_api(space_id)
+      stub_api_response(
+        :get, "spaces/#{space_id}/wiki/wiki_pages", filename: "wikis"
+      )
+    end
+
     private
 
     def ribose_endpoint(endpoint)


### PR DESCRIPTION
Ribose space contains one or multiple wiki pages and we also have and API resources that returns the list of wiki pages. This commit usages that endpoint and provide a ruby binding to retrieve the list easily.

```ruby
Ribose::Wiki.all(space_id, options = {})
```