### PR TITLE
Add interface to fetch a space wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,6 +535,12 @@ Ribose::User.activate(
 Ribose::Wiki.all(space_id, options = {})
 ```
 
+#### Fetch a wiki page
+
+```ruby
+Ribose::Wiki.fetch(space_id, wiki_id, options = {})
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/ribose/wiki.rb
+++ b/lib/ribose/wiki.rb
@@ -1,9 +1,26 @@
 module Ribose
   class Wiki < Ribose::Base
     include Ribose::Actions::All
+    include Ribose::Actions::Fetch
 
+    # List wiki pages
+    #
+    # @param space_id [String] The space UUID
+    # @param options [Hash] Query parameters
+    # @retrun [Array <Sawyer::Resoruce>]
+    #
     def self.all(space_id, options = {})
       new(space_id: space_id, **options).all
+    end
+
+    # Fetch a wiki page
+    #
+    # @param space_id [String] The space UUID
+    # @param wiki_id [String] The WiKI UUID
+    # @return [Sawyer::Resoruce]
+    #
+    def self.fetch(space_id, wiki_id, options = {})
+      new(space_id: space_id, resource_id: wiki_id, **options).fetch
     end
 
     private
@@ -19,7 +36,7 @@ module Ribose
     end
 
     def resources_path
-      ["spaces", space_id, "wiki", "wiki_pages"].join("/")
+      ["spaces", space_id, "wiki", resources].join("/")
     end
   end
 end

--- a/spec/fixtures/wiki.json
+++ b/spec/fixtures/wiki.json
@@ -1,0 +1,79 @@
+{
+  "wiki_page": {
+    "id": 7678,
+    "name": "Wiki Page One",
+    "address": "wiki-page-one",
+    "created_at": "2017-11-08T07:33:25.000+00:00",
+    "updated_at": "2017-11-08T07:33:25.000+00:00",
+    "version": 1,
+    "allow_attachments": true,
+    "allow_comments": true,
+    "revision": 23,
+    "tag_list": [
+      "wiki",
+      "init"
+    ],
+    "space_id": "52e47e18-9a9d-4663-94c5",
+    "attachments_listed": [],
+    "author_ids": [
+      "2970d105-5ccc"
+    ],
+    "is_new_record": false,
+    "rendered_created_by": "2970d105-5ccc",
+    "rendered_updated_by": "2970d105-5ccc",
+    "allow_create": true,
+    "allow_edit": true,
+    "allow_update": true,
+    "allow_delete": true,
+    "allow_comment": true,
+    "allow_manage_permissions": true,
+    "history": {
+      "current_ver": 1,
+      "versions": [
+        {
+          "id": 1,
+          "updater_id": "2970d105-5ccc",
+          "updated_at": "2017-11-08T07:33:25.000+00:00"
+        }
+      ]
+    },
+    "current_user": "2970d105-5ccc",
+    "related_users": {
+      "2970d105-5ccc": {
+        "id": "2970d105-5ccc",
+        "name": "John Doe",
+        "connected": true,
+        "mutual_spaces": [
+          "a7f7b94e-a007-4457-868f",
+          "a45387e2-a573-48ba",
+          "268b0407-c3a3-4aad-8693",
+          "52e47e18-9a9d-4663-94c5"
+        ]
+      }
+    },
+    "encoded_rendered_content": "This%26nbsp%3Bis%26nbsp%3Bthe%26nbsp%3Bfirst%26nbsp%3Bwiki%26nbsp%3Bpage%26nbsp%3Bfor%26nbsp%3BRibose!Hello%2C%26nbsp%3B",
+    "comments": [],
+    "user": {
+      "id": "2970d105-5ccc",
+      "name": "John Doe",
+      "connected": true,
+      "mutual_spaces": [
+        "a7f7b94e-a007-4457-868f",
+        "a45387e2-a573-48ba",
+        "268b0407-c3a3-4aad-8693",
+        "52e47e18-9a9d-4663-94c5"
+      ]
+    },
+    "updater": {
+      "id": "2970d105-5ccc",
+      "name": "John Doe",
+      "connected": true,
+      "mutual_spaces": [
+        "a7f7b94e-a007-4457-868f",
+        "a45387e2-a573-48ba",
+        "268b0407-c3a3-4aad-8693",
+        "52e47e18-9a9d-4663-94c5"
+      ]
+    }
+  }
+}

--- a/spec/ribose/wiki_spec.rb
+++ b/spec/ribose/wiki_spec.rb
@@ -13,4 +13,18 @@ RSpec.describe Ribose::Wiki do
       expect(wikis.last.name).to eq("Wiki Page Two")
     end
   end
+
+  describe ".fetch" do
+    it "retrieves the details for a wiki page" do
+      wiki_id = 456_789
+      space_id = 123_456
+
+      stub_ribose_wiki_fetch_api(space_id, wiki_id)
+      wiki = Ribose::Wiki.fetch(space_id, wiki_id)
+
+      expect(wiki.name).to eq("Wiki Page One")
+      expect(wiki.history.current_ver).to eq(1)
+      expect(wiki.updater.name).to eq("John Doe")
+    end
+  end
 end

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -339,6 +339,12 @@ module Ribose
       )
     end
 
+    def stub_ribose_wiki_fetch_api(sid, wiki_id)
+      stub_api_response(
+        :get, "spaces/#{sid}/wiki/wiki_pages/#{wiki_id}", filename: "wiki"
+      )
+    end
+
     private
 
     def ribose_endpoint(endpoint)


### PR DESCRIPTION
The Ribose API offers `GET /wiki/wiki_pages/:wiki_id` that returns the details for any specific wiki page, This commit utilize that endpoint and provide a ruby binding for that.

```ruby
Ribose::Wiki.fetch(space_id, wiki_id, options = {})
```