### PR TITLE
Add interface to create a new wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,6 +541,14 @@ Ribose::Wiki.all(space_id, options = {})
 Ribose::Wiki.fetch(space_id, wiki_id, options = {})
 ```
 
+#### Create a wiki page
+
+```ruby
+Ribose::Wiki.create(
+  space_id, name: "Wiki Name", tag_list: "sample", **other_attributes_hash
+)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/ribose/actions/all.rb
+++ b/lib/ribose/actions/all.rb
@@ -9,11 +9,10 @@ module Ribose
       # Retrieve the list of resources via :get and then extract the
       # the root element from the response object.
       #
-      # @param options [Hash] Query parameters as a Hash
       # @return [Array <Sawyer::Resource>]
       #
-      def all(options = {})
-        response = Ribose::Request.get(resources_path, options)
+      def all
+        response = Ribose::Request.get(resources_path, custom_option)
         extract_root(response) || response
       end
 
@@ -35,8 +34,8 @@ module Ribose
         # @param options [Hash] Query parameters as Hash
         # @return [Array <Sawyer::Resource>]
         #
-        def all(client: nil, **options)
-          new.all(client: client, query: options)
+        def all(options = {})
+          new(options).all
         end
       end
     end

--- a/lib/ribose/base.rb
+++ b/lib/ribose/base.rb
@@ -12,7 +12,7 @@ module Ribose
 
     private
 
-    attr_reader :resource_id, :attributes, :client
+    attr_reader :resource_id, :attributes, :client, :query
 
     # User provided options
     #
@@ -22,7 +22,7 @@ module Ribose
     # come in handy.
     #
     def custom_option
-      { client: client }
+      { client: client, query: query }
     end
 
     # Extract Local Attributes
@@ -40,6 +40,7 @@ module Ribose
     def extract_local_attributes; end
 
     def extract_base_attributes
+      @query = attributes.delete(:query)
       @client = attributes.delete(:client)
       @resource_id = attributes.delete(:resource_id)
     end

--- a/lib/ribose/connection.rb
+++ b/lib/ribose/connection.rb
@@ -13,7 +13,7 @@ module Ribose
     # @return [Sawyer::Resource]
     #
     def self.all(options = {})
-      new.all(options.merge(query: { s: "" }))
+      new(options.merge(query: { s: "" })).all
     end
 
     # List connection suggestions

--- a/lib/ribose/wiki.rb
+++ b/lib/ribose/wiki.rb
@@ -2,6 +2,7 @@ module Ribose
   class Wiki < Ribose::Base
     include Ribose::Actions::All
     include Ribose::Actions::Fetch
+    include Ribose::Actions::Create
 
     # List wiki pages
     #
@@ -23,6 +24,16 @@ module Ribose
       new(space_id: space_id, resource_id: wiki_id, **options).fetch
     end
 
+    # Create a wiki page
+    #
+    # @param space_id [String] The space UUID
+    # @param attributes [Hash] Wiki page attributes
+    # @return [Sawyer::Resoruce] Newly created wiki
+    #
+    def self.create(space_id, attributes)
+      new(space_id: space_id, **attributes).create
+    end
+
     private
 
     attr_reader :space_id
@@ -33,6 +44,10 @@ module Ribose
 
     def extract_local_attributes
       @space_id = attributes.delete(:space_id)
+    end
+
+    def validate(name:, **attributes)
+      attributes.merge(name: name)
     end
 
     def resources_path

--- a/spec/ribose/wiki_spec.rb
+++ b/spec/ribose/wiki_spec.rb
@@ -27,4 +27,17 @@ RSpec.describe Ribose::Wiki do
       expect(wiki.updater.name).to eq("John Doe")
     end
   end
+
+  describe ".create" do
+    it "creates a new wiki page in space" do
+      space_id = 123_456
+      attributes = { name: "Wiki Page One" }
+
+      stub_ribose_wiki_create_api(space_id, attributes)
+      wiki = Ribose::Wiki.create(space_id, attributes)
+
+      expect(wiki.id).not_to be_nil
+      expect(wiki.name).to eq(attributes[:name])
+    end
+  end
 end

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -345,6 +345,15 @@ module Ribose
       )
     end
 
+    def stub_ribose_wiki_create_api(space_id, attributes)
+      stub_api_response(
+        :post,
+        "spaces/#{space_id}/wiki/wiki_pages",
+        data: { wiki_page: attributes },
+        filename: "wiki",
+      )
+    end
+
     private
 
     def ribose_endpoint(endpoint)


### PR DESCRIPTION
The `POST /wiki/wiki_pages` endpoint allows a user to create a new wiki page for any of the existing space, and this commit usage that endpoint and provide a ruby binding for that.

```ruby
Ribose::Wiki.create( space_id, name: "Wiki Name", tag_list: "sample", **other_attributes)
```