### PR TITLE
Add interface to update a wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,14 @@ Ribose::Wiki.create(
 )
 ```
 
+### Update a wiki page
+
+```ruby
+Ribose::Wiki.update(
+  space_id, wiki_id, **updated_attributes_hash
+)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/ribose/wiki.rb
+++ b/lib/ribose/wiki.rb
@@ -3,6 +3,7 @@ module Ribose
     include Ribose::Actions::All
     include Ribose::Actions::Fetch
     include Ribose::Actions::Create
+    include Ribose::Actions::Update
 
     # List wiki pages
     #
@@ -17,7 +18,7 @@ module Ribose
     # Fetch a wiki page
     #
     # @param space_id [String] The space UUID
-    # @param wiki_id [String] The WiKI UUID
+    # @param wiki_id [String] The Wiki UUID
     # @return [Sawyer::Resoruce]
     #
     def self.fetch(space_id, wiki_id, options = {})
@@ -32,6 +33,18 @@ module Ribose
     #
     def self.create(space_id, attributes)
       new(space_id: space_id, **attributes).create
+    end
+
+    # Update a wiki page
+    #
+    # @param space_id [String] The space UUID
+    # @param wiki_id [String] The wiki-page UUID
+    # @param attributes [Hash] Wiki page attributes
+    #
+    # @return [Sawyer::Resoruce] Updated wiki page
+    #
+    def self.update(space_id, wiki_id, attributes)
+      new(space_id: space_id, resource_id: wiki_id, **attributes).update
     end
 
     private

--- a/spec/ribose/wiki_spec.rb
+++ b/spec/ribose/wiki_spec.rb
@@ -40,4 +40,18 @@ RSpec.describe Ribose::Wiki do
       expect(wiki.name).to eq(attributes[:name])
     end
   end
+
+  describe ".update" do
+    it "updates a wiki with provided details" do
+      wiki_id = 456_789
+      space_id = 123_456
+      attributes = { name: "Wiki Page One" }
+
+      stub_ribose_wiki_update_api(space_id, wiki_id, attributes)
+      wiki = Ribose::Wiki.update(space_id, wiki_id, attributes)
+
+      expect(wiki.id).not_to be_nil
+      expect(wiki.name).to eq("Wiki Page One")
+    end
+  end
 end

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -354,6 +354,15 @@ module Ribose
       )
     end
 
+    def stub_ribose_wiki_update_api(space_id, wiki_id, attributes)
+      stub_api_response(
+        :put,
+        "spaces/#{space_id}/wiki/wiki_pages/#{wiki_id}",
+        data: { wiki_page: attributes },
+        filename: "wiki",
+      )
+    end
+
     private
 
     def ribose_endpoint(endpoint)


### PR DESCRIPTION
The Ribose API offers `PUT /wiki/wiki_pages/:wiki_id` endpoint that allows a user to update on the existing wiki page, and this commit utilize that endpoint and provide a ruby binding. Usage

```ruby
Ribose::Wiki.update(
  space_id, wiki_id, **updated_attributes_hash
)
```