### PR TITLE
Add interface to delete a wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,12 @@ Ribose::Wiki.update(
 )
 ```
 
+### Remove a wiki page
+
+```ruby
+Ribose::Wiki.delete(space_id, wiki_id)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/ribose/wiki.rb
+++ b/lib/ribose/wiki.rb
@@ -4,6 +4,7 @@ module Ribose
     include Ribose::Actions::Fetch
     include Ribose::Actions::Create
     include Ribose::Actions::Update
+    include Ribose::Actions::Delete
 
     # List wiki pages
     #
@@ -45,6 +46,15 @@ module Ribose
     #
     def self.update(space_id, wiki_id, attributes)
       new(space_id: space_id, resource_id: wiki_id, **attributes).update
+    end
+
+    # Delete a wiki page
+    #
+    # @param space_id [String] The space UUID
+    # @param wiki_id [String] The wiki-page UUID
+    #
+    def self.delete(space_id, wiki_id, options = {})
+      new(space_id: space_id, resource_id: wiki_id, **options).delete
     end
 
     private

--- a/spec/ribose/wiki_spec.rb
+++ b/spec/ribose/wiki_spec.rb
@@ -54,4 +54,14 @@ RSpec.describe Ribose::Wiki do
       expect(wiki.name).to eq("Wiki Page One")
     end
   end
+
+  describe ".delete" do
+    it "deletes an existing space wiki page" do
+      wiki_id = 456_789
+      space_id = 123_456
+
+      stub_ribose_wiki_delete_api(space_id, wiki_id)
+      expect { Ribose::Wiki.delete(space_id, wiki_id) }.not_to raise_error
+    end
+  end
 end

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -363,6 +363,12 @@ module Ribose
       )
     end
 
+    def stub_ribose_wiki_delete_api(sid, wiki_id)
+      stub_api_response(
+        :delete, "spaces/#{sid}/wiki/wiki_pages/#{wiki_id}", filename: "empty"
+      )
+    end
+
     private
 
     def ribose_endpoint(endpoint)


### PR DESCRIPTION
The Ribose API offers `DELETE /wiki/wiki_pagges/:wiki_id` endpoint that allows a user to delete on the existing wiki page from space and this commit usage that endpoint and provide a ruby binding

```ruby
Ribose::Wiki.delete(space_id, wiki_id)
```