### PR TITLE
Interface to remove a user's space

### DIFF
--- a/lib/ribose/space.rb
+++ b/lib/ribose/space.rb
@@ -15,6 +15,10 @@ module Ribose
       Ribose::Request.post("spaces/#{space_uuid}/freeze", options)
     end
 
+    def self.delete(space_uuid, confirmation:, **options)
+      remove(space_uuid, options.merge(password_confirmation: confirmation))
+    end
+
     private
 
     attr_reader :space

--- a/spec/ribose/space_spec.rb
+++ b/spec/ribose/space_spec.rb
@@ -59,6 +59,17 @@ RSpec.describe Ribose::Space do
     end
   end
 
+  describe ".delete" do
+    it "deletes an existing space" do
+      space_id = 123_456_789
+      stub_ribose_space_remove_api(space_id, password_confirmation: 1234)
+
+      expect do
+        Ribose::Space.delete(space_id, confirmation: 1234)
+      end.not_to raise_error
+    end
+  end
+
   def space_attributes
     {
       access: "private",

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -30,6 +30,12 @@ module Ribose
       )
     end
 
+    def stub_ribose_space_delete_api(space_id, options = {})
+      stub_api_response(
+        :delete, "spaces/#{space_id}", data: options, filename: "empty"
+      )
+    end
+
     def stub_ribose_feed_api
       stub_api_response(:get, "feeds", filename: "feeds")
     end


### PR DESCRIPTION
In Ribose application a user can remove a space they own, and we wanted to have the similar interface in the client, this commit adds that behavior so now user can remove a space using ribose client as well. Usages:

```ruby
Ribose::Space.delete(space_uuid, confirmation: user_password)
```

Issue: #78