### PR TITLE
Bump the gem to version 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 0.2.0 (2017-11-30)
+
+Features:
+
+ - Initial functional release.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 Status](https://travis-ci.org/riboseinc/ribose-ruby.svg?branch=master)](https://travis-ci.org/riboseinc/ribose-ruby)
 [![Code
 Climate](https://codeclimate.com/github/riboseinc/ribose-ruby/badges/gpa.svg)](https://codeclimate.com/github/riboseinc/ribose-ruby)
+[![Gem Version](https://badge.fury.io/rb/ribose.svg)](https://badge.fury.io/rb/ribose)
 
 The Ruby Interface to the Ribose API.
 

--- a/lib/ribose/version.rb
+++ b/lib/ribose/version.rb
@@ -1,3 +1,3 @@
 module Ribose
-  VERSION = "0.1.0".freeze
+  VERSION = "0.2.0".freeze
 end


### PR DESCRIPTION
We have been working on the gem for a while, but the last release we did was a quite while back, and it's kind not fully functional. So this commit bump the version to `0.2.0` which should be functionality with most of our API endpoints.