### PR TITLE
Add interface to delete a space member

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,12 +187,18 @@ The members endpoint are Space-specific.
 To retrieve the member details under any specific Space, we can use this
 interface.
 
-### List of Members
+#### List space members
 
 To retrieve the list of members,
 
 ```ruby
 Ribose::Member.all(space_id, options)
+```
+
+#### Delete a space member
+
+```ruby
+Ribose::Member.delete(space_id, member_id, options)
 ```
 
 ### Files

--- a/lib/ribose/member.rb
+++ b/lib/ribose/member.rb
@@ -1,6 +1,7 @@
 module Ribose
   class Member < Ribose::Base
     include Ribose::Actions::All
+    include Ribose::Actions::Delete
 
     # List A Space Members
     #
@@ -13,6 +14,16 @@ module Ribose
     #
     def self.all(space_id, options = {})
       new(space_id: space_id, **options).all
+    end
+
+    # Delete a space member
+    #
+    # @param space_id [String] The Space UUID
+    # @param member_id [String] The Member UUID
+    # @param options [Hash] Query parameters as Hash
+    #
+    def self.delete(space_id, member_id, options = {})
+      new(space_id: space_id, resource_id: member_id, **options).delete
     end
 
     private

--- a/spec/ribose/member_spec.rb
+++ b/spec/ribose/member_spec.rb
@@ -13,4 +13,14 @@ RSpec.describe Ribose::Member do
       expect(members.first.role_name_in_space).to eq("Administrator")
     end
   end
+
+  describe ".delete" do
+    it "deletes a member from a space" do
+      space_id = 123_456_789
+      member_id = 456_789_012
+
+      stub_ribose_space_member_delete_api(space_id, member_id)
+      expect { Ribose::Member.delete(space_id, member_id) }.not_to raise_error
+    end
+  end
 end

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -38,6 +38,12 @@ module Ribose
       stub_api_response(:get, "spaces/#{space_id}/members", filename: "members")
     end
 
+    def stub_ribose_space_member_delete_api(space_id, member_id)
+      stub_api_response(
+        :delete, "spaces/#{space_id}/members/#{member_id}", filename: "empty"
+      )
+    end
+
     def stub_ribose_setting_list_api
       stub_api_response(:get, "settings", filename: "settings")
     end


### PR DESCRIPTION
The Ribose API offers `DELETE /spaces/:space_id/members/:member_id` which allow us to remove a member from a user space, and this commit usages that interface and provides a ruby binding for that.

```ruby
Ribose::Member.delete(space_id, member_id, options)
```