### PR TITLE
Interface to fetch role for a member

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,12 @@ Ribose::Member.all(space_id, options)
 Ribose::Member.delete(space_id, member_id, options)
 ```
 
+#### Fetch Member Role
+
+```ruby
+Ribose::MemberRole.fetch(space_id, member_id, options)
+```
+
 ### Files
 
 #### List of Files

--- a/lib/ribose.rb
+++ b/lib/ribose.rb
@@ -27,6 +27,7 @@ require "ribose/user"
 require "ribose/session"
 require "ribose/profile"
 require "ribose/wiki"
+require "ribose/member_role"
 
 module Ribose
   def self.root

--- a/lib/ribose/member_role.rb
+++ b/lib/ribose/member_role.rb
@@ -1,0 +1,26 @@
+module Ribose
+  class MemberRole < Ribose::Base
+    include Ribose::Actions::Fetch
+
+    # Fetch Member Role
+    #
+    # @param space_id [String] The Space UUID
+    # @param user_id [String] The Member UUID
+    # @param options [Hash] Query parameters as Hash
+    # @return [Sawyer::Resoruce] Mmeber role in space
+    #
+    def self.fetch(space_id, user_id, options = {})
+      new(resource_id: user_id, query: { in_space: space_id }, **options).fetch
+    end
+
+    private
+
+    def resource
+      nil
+    end
+
+    def resource_path
+      ["people", "users", resource_id, "roles", "get_roles"].join("/")
+    end
+  end
+end

--- a/spec/fixtures/member_role.json
+++ b/spec/fixtures/member_role.json
@@ -1,0 +1,19 @@
+{
+  "roles":[
+    {
+      "id":91877,
+      "name":"Member",
+      "space_id":"77b9d5102fb0-457e8438-1c6f"
+    },
+    {
+      "id":91878,
+      "name":"Administrator",
+      "space_id":"77b9d5102fb0-457e8438-1c6f"
+    }
+  ],
+  "user_role":{
+    "id":91878,
+    "name":"Administrator",
+    "space_id":"77b9d5102fb0-457e8438-1c6f"
+  }
+}

--- a/spec/ribose/member_role_spec.rb
+++ b/spec/ribose/member_role_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+RSpec.describe Ribose::MemberRole do
+  describe ".fetch" do
+    it "retrieves the role for a member in a space" do
+      space_id = 123_456_789
+      member_id = 456_789_012
+
+      stub_ribose_member_role_fetch_api(space_id, member_id)
+      member_role = Ribose::MemberRole.fetch(space_id, member_id)
+
+      expect(member_role.roles.first.name).to eq("Member")
+      expect(member_role.roles.last.name).to eq("Administrator")
+    end
+  end
+end

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -44,6 +44,14 @@ module Ribose
       )
     end
 
+    def stub_ribose_member_role_fetch_api(space_id, user_id)
+      stub_api_response(
+        :get,
+        "people/users/#{user_id}/roles/get_roles?in_space=#{space_id}",
+        filename: "member_role",
+      )
+    end
+
     def stub_ribose_setting_list_api
       stub_api_response(:get, "settings", filename: "settings")
     end


### PR DESCRIPTION
The Ribose API offers an endpoint to retrieve the roles for a member in any given space. This commit usages that and providesna ruby binding, so we can easily fetch member's role.

```ruby
Ribose::MemberRole.fetch(space_id, member_id, options)
```