### PR TITLE
Add interface to assign a member role

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,12 @@ Ribose::Member.delete(space_id, member_id, options)
 Ribose::MemberRole.fetch(space_id, member_id, options)
 ```
 
+#### Assign a role to member
+
+```ruby
+Ribose::MemberRole.assign(space_id, member_id, role_id)
+```
+
 ### Files
 
 #### List of Files

--- a/lib/ribose/member_role.rb
+++ b/lib/ribose/member_role.rb
@@ -2,6 +2,10 @@ module Ribose
   class MemberRole < Ribose::Base
     include Ribose::Actions::Fetch
 
+    def assign
+      assign_member_role
+    end
+
     # Fetch Member Role
     #
     # @param space_id [String] The Space UUID
@@ -10,17 +14,48 @@ module Ribose
     # @return [Sawyer::Resoruce] Mmeber role in space
     #
     def self.fetch(space_id, user_id, options = {})
-      new(resource_id: user_id, query: { in_space: space_id }, **options).fetch
+      new(resource_id: user_id, space_id: space_id, **options).fetch
+    end
+
+    # Assign Role to a Member
+    #
+    # @param space_id [String] The Space UUID
+    # @param user_id [String] The Member UUID
+    # @param role_id [String] The role id in space
+    #
+    def self.assign(space_id, user_id, role_id)
+      new(space_id: space_id, resource_id: user_id, role_id: role_id).assign
     end
 
     private
+
+    attr_reader :role_id
 
     def resource
       nil
     end
 
+    def assign_path
+      [resources_path, "change_assignment"].join("/")
+    end
+
     def resource_path
-      ["people", "users", resource_id, "roles", "get_roles"].join("/")
+      [resources_path, "get_roles"].join("/")
+    end
+
+    def resources_path
+      ["people", "users", resource_id, "roles"].join("/")
+    end
+
+    def extract_local_attributes
+      @role_id = attributes.delete(:role_id)
+      @query = { in_space: attributes.delete(:space_id) }
+    end
+
+    def assign_member_role
+      Ribose::Request.put(
+        assign_path, custom_option.merge(checked_role: role_id)
+      )
     end
   end
 end

--- a/spec/ribose/member_role_spec.rb
+++ b/spec/ribose/member_role_spec.rb
@@ -13,4 +13,18 @@ RSpec.describe Ribose::MemberRole do
       expect(member_role.roles.last.name).to eq("Administrator")
     end
   end
+
+  describe ".assign" do
+    it "assigns a role to a member in a space" do
+      role_id = 789_123_456
+      space_id = 123_456_789
+      member_id = 456_789_012
+
+      stub_ribose_member_role_assign(space_id, member_id, role_id)
+
+      expect do
+        Ribose::MemberRole.assign(space_id, member_id, role_id)
+      end.not_to raise_error
+    end
+  end
 end

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -52,6 +52,15 @@ module Ribose
       )
     end
 
+    def stub_ribose_member_role_assign(space_id, user_id, role_id)
+      stub_api_response(
+        :put,
+        "people/users/#{user_id}/roles/change_assignment?in_space=#{space_id}",
+        data: { checked_role: role_id },
+        filename: "empty",
+      )
+    end
+
     def stub_ribose_setting_list_api
       stub_api_response(:get, "settings", filename: "settings")
     end


### PR DESCRIPTION
The Ribose API offers an API endpoint that allows us to set a role to member for any specified space. This commit utilize that endpoint and provides a ruby binding for that, usages:

```ruby
Ribose::MemberRole.assign(space_id, member_id, role_id)
```

Closes #77