### PR TITLE
WIP: Add interface for wiki increments

### DIFF
--- a/lib/ribose.rb
+++ b/lib/ribose.rb
@@ -28,6 +28,7 @@ require "ribose/session"
 require "ribose/profile"
 require "ribose/wiki"
 require "ribose/member_role"
+require "ribose/wiki_increment"
 
 module Ribose
   def self.root

--- a/lib/ribose/wiki_increment.rb
+++ b/lib/ribose/wiki_increment.rb
@@ -1,0 +1,33 @@
+module Ribose
+  class WikiIncrement < Ribose::Base
+    include Ribose::Actions::Create
+
+    # Create wiki increments
+    #
+    # @param space_id [String] The space UUID
+    # @param wiki_id [String] The wiki page UUID
+    # @param optinons [Hash] Query parametars as Hash
+    # @return [Sawyer::Resources] New wiki increment
+    #
+    def self.create(space_id:, wiki_id:, **attributes)
+      new(space_id: space_id, wiki_id: wiki_id, **attributes).create
+    end
+
+    private
+
+    attr_reader :space_id, :wiki_id
+
+    def resource
+      "increment"
+    end
+
+    def extract_local_attributes
+      @wiki_id = attributes.delete(:wiki_id)
+      @space_id = attributes.delete(:space_id)
+    end
+
+    def resources_path
+      ["spaces", space_id, "wiki/wiki_pages", wiki_id, "increments"].join("/")
+    end
+  end
+end

--- a/spec/ribose/wiki_increment_spec.rb
+++ b/spec/ribose/wiki_increment_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+
+RSpec.describe Ribose::WikiIncrement do
+  describe ".create" do
+    it "creates a new wiki page increment" do
+      wiki_id = 789_123_567
+      space_id = 123_456_789
+
+      increment = Ribose::WikiIncrement.create(
+        wiki_id: wiki_id, space_id: space_id, **increment_attrs
+      )
+    end
+  end
+  # describe ".all" do
+  #   it "retrieves the list of wiki increments" do
+  #     wiki_id = 789_123_567
+  #     space_id = 123_456_789
+  #
+  #     increments = Ribose::WikiIncrement.all(space_id, wiki_id)
+  #   end
+  # end
+  #
+  def increment_attrs
+    {
+      revision: 0,
+      delta: { ops: [{ insert: "a" }] },
+    }
+  end
+end


### PR DESCRIPTION
Editing the Note from anywhere other than the web interface is something we've never considered before, but is something we find useful in user acceptance test setup.  There are some parameters that are actually required but provided implicitly in the web UI, which are missing from the API doc at the time of writing.

We're now reconsidering the way this endpoint works and once we have something finalized then maybe we can get back to this one

Ref: Sir. Jeffery :)