### PR TITLE
Add interface to fetch a join space request

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,12 @@ Ribose::SpaceInvitation.cancel(invitation_id)
 Ribose::JoinSpaceRequest.all
 ```
 
+#### Fetch a join space request
+
+```ruby
+Ribose::JoinSpaceRequest.fetch(request_id)
+```
+
 #### Create a Join Space Request
 
 ```ruby

--- a/lib/ribose/join_space_request.rb
+++ b/lib/ribose/join_space_request.rb
@@ -1,6 +1,7 @@
 module Ribose
   class JoinSpaceRequest < Ribose::Base
     include Ribose::Actions::All
+    include Ribose::Actions::Fetch
     include Ribose::Actions::Create
     include Ribose::Actions::Update
 

--- a/spec/fixtures/join_space_request.json
+++ b/spec/fixtures/join_space_request.json
@@ -1,0 +1,32 @@
+{
+  "join_space_request": {
+    "id": 123456789,
+    "email": "",
+    "body": null,
+    "created_at": "",
+    "state": 0,
+    "type": "Invitation::ToSpace",
+    "updated_at": "",
+    "invitee": {
+      "id": "109EF27E",
+      "connected": true,
+      "name": "Joe Public",
+      "mutual_spaces": [
+        ""
+      ]
+    },
+    "inviter": {
+      "id": "109EF27E",
+      "connected": true,
+      "name": "John Doe",
+      "mutual_spaces": [
+        ""
+      ]
+    },
+    "space": {
+      "id": "948AD10F",
+      "name": "My first space",
+      "members_count": 10
+    }
+  }
+}

--- a/spec/ribose/join_space_request_spec.rb
+++ b/spec/ribose/join_space_request_spec.rb
@@ -11,6 +11,19 @@ RSpec.describe Ribose::JoinSpaceRequest do
     end
   end
 
+  describe ".fetch" do
+    it "retrieves the details for a join space request" do
+      invitation_id = 123_456_789
+
+      stub_ribose_join_space_request_fetch_api(invitation_id)
+      invitation = Ribose::JoinSpaceRequest.fetch(invitation_id)
+
+      expect(invitation.id).not_to be_nil
+      expect(invitation.inviter.name).to eq("John Doe")
+      expect(invitation.type).to eq("Invitation::ToSpace")
+    end
+  end
+
   describe ".create" do
     it "creates a new join space request" do
       attributes = {

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -319,6 +319,14 @@ module Ribose
       )
     end
 
+    def stub_ribose_join_space_request_fetch_api(invitation_id)
+      stub_api_response(
+        :get,
+        ["invitations", "join_space_request", invitation_id].join("/"),
+        filename: "join_space_request",
+      )
+    end
+
     def stub_ribose_join_space_request_create_api(attributes)
       stub_api_response(
         :post,


### PR DESCRIPTION
This commit adds the interface to fetch the join space request, the changes are pretty minimal, it only includes the `Fetch` module that allows us to fetch the details. To fetch any join space request

```ruby
Ribose::JoinSpaceRequest.fetch(request_id)
```