### PR TITLE
Add interface to retrieve a file details

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,12 @@ To retrieve the list of files for any specific Space,
 Ribose::SpaceFile.all(space_id, options)
 ```
 
+#### Fetch a file details
+
+```ruby
+Ribose::SpaceFile.fetch(space_id, file_id, options = {})
+```
+
 ### Create a file upload
 
 ```ruby

--- a/lib/ribose/space_file.rb
+++ b/lib/ribose/space_file.rb
@@ -3,6 +3,7 @@ require "ribose/file_uploader"
 module Ribose
   class SpaceFile < Ribose::Base
     include Ribose::Actions::All
+    include Ribose::Actions::Fetch
 
     # List Files for Space
     #
@@ -16,6 +17,19 @@ module Ribose
     #
     def self.all(space_id, options = {})
       new(space_id: space_id, **options).all
+    end
+
+    # Fetch a space file
+    #
+    # This interface retrieve the details for a single file in any
+    # given user space. The response is a `Sawyer::Resource`.
+    #
+    # @param space_id [String] The space UUID
+    # @param file_id [String] The space file ID
+    # @return [Sawyer::Resource]
+    #
+    def self.fetch(space_id, file_id, options = {})
+      new(space_id: space_id, resource_id: file_id, **options).fetch
     end
 
     # Create a new file upload

--- a/spec/fixtures/space_file.json
+++ b/spec/fixtures/space_file.json
@@ -1,58 +1,33 @@
 {
-  "files": [
-    {
-      "id": 9896,
-      "created_at": "2017-08-14T08:57:49.000+00:00",
-      "updated_at": "2017-08-14T08:57:50.000+00:00",
-      "name": "sample-file.png",
-      "description": "",
-      "version": 1,
-      "tag_list": [],
-      "content_size": 58784,
-      "content_type": "image/png",
-      "author": "Abu Nashir",
-      "allow_update": true,
-      "allow_create": true,
-      "allow_edit": true,
-      "allow_delete": true,
-      "allow_download": true,
-      "current_version_id": 11559,
-      "versions": [
-        {
-          "version": 1,
-          "name": "sample-file.png",
-          "updated_at": "2017-08-14T08:57:50.000+00:00",
-          "position": 1,
-          "current_version_id": 11559,
-          "icon_path": "https://assets-2-us-d1bd645.ribose.com/assets/files/placeholder-thumb-59ea90c30f07829d1dc87ce0dfffaeaf.png",
-          "content_size": 58784,
-          "author": "John Doe"
-        }
-      ]
-    }
-  ],
-  "recent_activity": [
-    {
-      "date": "Monday, August 14, 2017",
-      "links": [
-        {
-          "id": 9896,
-          "name": "sample-file.png",
-          "path": "/#spaces/0e8d5c16-1a31-4df9-83d9-eeaa374d5adc/file/files/9896/versions/11559"
-        }
-      ]
-    }
-  ],
-  "tags": {
-    "selected_tags": [],
-    "related_tags": [],
-    "all_tags": []
-  },
-  "permissions": {
+  "file": {
+    "id": 9896,
+    "created_at": "2017-08-14T08:57:49.000+00:00",
+    "updated_at": "2017-08-14T08:57:50.000+00:00",
+    "name": "sample-file.png",
+    "description": "",
+    "version": 1,
+    "tag_list": [],
+    "content_size": 58784,
+    "content_type": "image/png",
+    "author": "Abu Nashir",
+    "allow_update": true,
     "allow_create": true,
-    "allow_download": true,
     "allow_edit": true,
     "allow_delete": true,
-    "allow_mass_actions": true
+    "allow_download": true,
+    "current_version_id": 11559,
+    "versions": [
+      {
+        "version": 1,
+        "name": "sample-file.png",
+        "updated_at": "2017-08-14T08:57:50.000+00:00",
+        "position": 1,
+        "current_version_id": 11559,
+        "icon_path": "https://assets-2-us-d1bd645.ribose.com/assets/files/placeholder-thumb-59ea90c30f07829d1dc87ce0dfffaeaf.png",
+        "content_size": 58784,
+        "author": "John Doe"
+      }
+    ]
   }
+
 }

--- a/spec/fixtures/space_files.json
+++ b/spec/fixtures/space_files.json
@@ -1,0 +1,58 @@
+{
+  "files": [
+    {
+      "id": 9896,
+      "created_at": "2017-08-14T08:57:49.000+00:00",
+      "updated_at": "2017-08-14T08:57:50.000+00:00",
+      "name": "sample-file.png",
+      "description": "",
+      "version": 1,
+      "tag_list": [],
+      "content_size": 58784,
+      "content_type": "image/png",
+      "author": "Abu Nashir",
+      "allow_update": true,
+      "allow_create": true,
+      "allow_edit": true,
+      "allow_delete": true,
+      "allow_download": true,
+      "current_version_id": 11559,
+      "versions": [
+        {
+          "version": 1,
+          "name": "sample-file.png",
+          "updated_at": "2017-08-14T08:57:50.000+00:00",
+          "position": 1,
+          "current_version_id": 11559,
+          "icon_path": "https://assets-2-us-d1bd645.ribose.com/assets/files/placeholder-thumb-59ea90c30f07829d1dc87ce0dfffaeaf.png",
+          "content_size": 58784,
+          "author": "John Doe"
+        }
+      ]
+    }
+  ],
+  "recent_activity": [
+    {
+      "date": "Monday, August 14, 2017",
+      "links": [
+        {
+          "id": 9896,
+          "name": "sample-file.png",
+          "path": "/#spaces/0e8d5c16-1a31-4df9-83d9-eeaa374d5adc/file/files/9896/versions/11559"
+        }
+      ]
+    }
+  ],
+  "tags": {
+    "selected_tags": [],
+    "related_tags": [],
+    "all_tags": []
+  },
+  "permissions": {
+    "allow_create": true,
+    "allow_download": true,
+    "allow_edit": true,
+    "allow_delete": true,
+    "allow_mass_actions": true
+  }
+}

--- a/spec/ribose/space_file_spec.rb
+++ b/spec/ribose/space_file_spec.rb
@@ -14,6 +14,20 @@ RSpec.describe Ribose::SpaceFile do
     end
   end
 
+  describe ".fetch" do
+    it "retrieves the details for a file" do
+      file_id = 456_789_012
+      space_id = 123_456_789
+
+      stub_ribose_space_file_fetch_api(space_id, file_id)
+      file = Ribose::SpaceFile.fetch(space_id, file_id)
+
+      expect(file.id).not_to be_nil
+      expect(file.name).to eq("sample-file.png")
+      expect(file.content_type).to eq("image/png")
+    end
+  end
+
   describe ".create" do
     it "creates a new file with provided details" do
       space_id = 123_456_789

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -137,6 +137,11 @@ module Ribose
 
     def stub_ribose_space_file_list(space_id)
       file_endppoint = ["spaces", space_id, "file", "files"].join("/")
+      stub_api_response(:get, file_endppoint, filename: "space_files")
+    end
+
+    def stub_ribose_space_file_fetch_api(space_id, file_id)
+      file_endppoint = ["spaces", space_id, "file", "files", file_id].join("/")
       stub_api_response(:get, file_endppoint, filename: "space_file")
     end
 


### PR DESCRIPTION
This commit adds the interface to retrieve the details for a file in any given user space. This interface expects us to provide the `space_id` and `file_id` as required parameter and it also allow us to pass an additional `option` hash with additional details.

```ruby
Ribose::SpaceFile.fetch(space_id, file_id, options = {})
```