### PR TITLE
Add interface to update a space file

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,10 +229,16 @@ Ribose::SpaceFile.all(space_id, options)
 Ribose::SpaceFile.fetch(space_id, file_id, options = {})
 ```
 
-### Create a file upload
+#### Create a file upload
 
 ```ruby
 Ribose::SpaceFile.create(space_id, file: "The complete file path", **attributes)
+```
+
+#### Update a space file
+
+```ruby
+Ribose::SpaceFile.update(space_id, file_id, new_file_attributes = {})
 ```
 
 ### Conversations

--- a/lib/ribose/space_file.rb
+++ b/lib/ribose/space_file.rb
@@ -4,6 +4,7 @@ module Ribose
   class SpaceFile < Ribose::Base
     include Ribose::Actions::All
     include Ribose::Actions::Fetch
+    include Ribose::Actions::Update
 
     # List Files for Space
     #
@@ -44,12 +45,27 @@ module Ribose
       upload[:attachment]
     end
 
+    # Update a space file
+    #
+    # @param space_id [String] The Space UUID
+    # @param file_id [String] The space file ID
+    # @param attributes [Hash] The file attributes
+    # @return [Sawyer::Resource]
+    #
+    def self.update(space_id, file_id, attributes)
+      new(space_id: space_id, resource_id: file_id, **attributes).update
+    end
+
     private
 
     attr_reader :space_id
 
     def resource
       "file"
+    end
+
+    def resource_key
+      "file_info"
     end
 
     def resources_path

--- a/spec/ribose/space_file_spec.rb
+++ b/spec/ribose/space_file_spec.rb
@@ -41,6 +41,22 @@ RSpec.describe Ribose::SpaceFile do
     end
   end
 
+  describe ".update" do
+    it "updates the details for a space file" do
+      file_id = 456_789_012
+      space_id = 123_456_789
+
+      attributes = { name: "sample-file.png", description: "description" }
+      stub_ribose_space_file_update_api(space_id, file_id, attributes)
+
+      file = Ribose::SpaceFile.update(space_id, file_id, attributes)
+
+      expect(file.id).not_to be_nil
+      expect(file.name).to eq("sample-file.png")
+      expect(file.content_type).to eq("image/png")
+    end
+  end
+
   def file_attributes
     {
       file: sample_fixture_file,

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -145,6 +145,15 @@ module Ribose
       stub_api_response(:get, file_endppoint, filename: "space_file")
     end
 
+    def stub_ribose_space_file_update_api(space_id, file_id, attributes)
+      stub_api_response(
+        :put,
+        ["spaces", space_id, "file", "files", file_id].join("/"),
+        data: { file_info: attributes },
+        filename: "space_file",
+      )
+    end
+
     def stub_ribose_space_conversation_list(space_id)
       stub_api_response(
         :get, conversations_path(space_id), filename: "conversations"


### PR DESCRIPTION
This commit adds the interface to update a space file, it expects us to pass `space_id`, `file_id` and the `new_attributes for the given file. Usage:

```ruby
Ribose::SpaceFile.update(space_id, file_id, new_file_attributes)
```