### PR TITLE
Add interface to remove a space file

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,12 @@ Ribose::SpaceFile.create(space_id, file: "The complete file path", **attributes)
 Ribose::SpaceFile.update(space_id, file_id, new_file_attributes = {})
 ```
 
+#### Remove a space file
+
+```ruby
+Ribose::SpaceFile.delete(space_id, file_id)
+```
+
 ### Conversations
 
 #### Listing Space Conversations

--- a/lib/ribose/space_file.rb
+++ b/lib/ribose/space_file.rb
@@ -5,6 +5,7 @@ module Ribose
     include Ribose::Actions::All
     include Ribose::Actions::Fetch
     include Ribose::Actions::Update
+    include Ribose::Actions::Delete
 
     # List Files for Space
     #
@@ -54,6 +55,15 @@ module Ribose
     #
     def self.update(space_id, file_id, attributes)
       new(space_id: space_id, resource_id: file_id, **attributes).update
+    end
+
+    # Delete a space file
+    #
+    # @param space_id [String] The Space UUID
+    # @param file_id [String] The space file ID
+    #
+    def self.delete(space_id, file_id, options = {})
+      new(space_id: space_id, resource_id: file_id, **options).delete
     end
 
     private

--- a/spec/ribose/space_file_spec.rb
+++ b/spec/ribose/space_file_spec.rb
@@ -57,6 +57,16 @@ RSpec.describe Ribose::SpaceFile do
     end
   end
 
+  describe ".delete" do
+    it "removes a specified space file" do
+      file_id = 456_789_012
+      space_id = 123_456_789
+
+      stub_ribose_space_file_delete_api(space_id, file_id)
+      expect { Ribose::SpaceFile.delete(space_id, file_id) }.not_to raise_error
+    end
+  end
+
   def file_attributes
     {
       file: sample_fixture_file,

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -154,6 +154,11 @@ module Ribose
       )
     end
 
+    def stub_ribose_space_file_delete_api(space_id, file_id)
+      file_endppoint = ["spaces", space_id, "file", "files", file_id].join("/")
+      stub_api_response(:delete, file_endppoint, filename: "empty")
+    end
+
     def stub_ribose_space_conversation_list(space_id)
       stub_api_response(
         :get, conversations_path(space_id), filename: "conversations"


### PR DESCRIPTION
This commit adds the interface to remove a space file, on success it return an success response but if it fails then it will raise an exception. Usage

```ruby
Ribose::SpaceFile.delete(space_id, file_id, options = {})
```