### PR TITLE
Add support to retrieve calendar events

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,10 +532,10 @@ To retrieve the list of calendars accessible to the current user,
 Ribose::Calendar.all
 ```
 
-#### Fetch a calendar
+#### Fetch a calendar events
 
 ```ruby
-Ribose::Calendar.fetch(calendar_id)
+Ribose::Calendar.fetch(calendar_ids, start: Data.today, length: 7)
 ```
 
 #### Create a calendar

--- a/lib/ribose.rb
+++ b/lib/ribose.rb
@@ -33,4 +33,9 @@ module Ribose
   def self.root
     File.dirname(__dir__)
   end
+
+  def self.encode_ids(resource_ids)
+    require "id_pack"
+    IdPack::IdPacker.new.encode([resource_ids].flatten)
+  end
 end

--- a/lib/ribose/calendar.rb
+++ b/lib/ribose/calendar.rb
@@ -1,9 +1,28 @@
+require "date"
+
 module Ribose
   class Calendar < Ribose::Base
     include Ribose::Actions::All
     include Ribose::Actions::Fetch
     include Ribose::Actions::Create
     include Ribose::Actions::Delete
+
+    # Fetch calendar events
+    #
+    # @params calendar_ids [Array] List of calendar Ids
+    # @params start [Date] The start date to fetch events
+    # @params length [Integer] How many days to fetch
+    # @return [Sawyer::Resource] The calendar events
+    #
+    def self.fetch(calendar_ids, start: Date.today, length: 7)
+      query = {
+        length: length,
+        cal_ids: Ribose.encode_ids(calendar_ids),
+        start: start.to_time.to_i / (60 * 60 * 24),
+      }
+
+      super(nil, query: query)
+    end
 
     private
 

--- a/ribose.gemspec
+++ b/ribose.gemspec
@@ -20,9 +20,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = `git ls-files -- {spec}/*`.split("\n")
   spec.required_ruby_version = Gem::Requirement.new(">= 2.1.9")
 
-  spec.add_dependency "sawyer", "~> 0.8.1"
-  spec.add_dependency "mime-types", "~> 3.1"
+  spec.add_dependency "id_pack", "~> 1.0.1"
   spec.add_dependency "mechanize", "~> 2.7.5"
+  spec.add_dependency "mime-types", "~> 3.1"
+  spec.add_dependency "sawyer", "~> 0.8.1"
 
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/fixtures/calendar_events.json
+++ b/spec/fixtures/calendar_events.json
@@ -1,0 +1,36 @@
+{
+  "head_events": [],
+  "indices": {
+    "17599": [],
+    "17600": [],
+    "17601": [],
+    "17602": [],
+    "17603": [
+      129258
+    ],
+    "17604": [],
+    "17605": []
+  },
+  "events": [
+    {
+      "id": 129258,
+      "name": "Sample event",
+      "description": "",
+      "where": "",
+      "all_day": true,
+      "recurring_type": "not_repeat",
+      "my_note": null,
+      "old_head_id": null,
+      "calendar_id": 123,
+      "created_by": "2970d105-5ccc-4a8c-b0c4",
+      "utc_start": "2018-03-13T12:00:00.000Z",
+      "utc_finish": "2018-03-13T13:00:00.000Z",
+      "utc_old_start": null,
+      "utc_old_finish": null,
+      "can_save": true,
+      "can_delete": true,
+      "timestamp": 1520690119
+    }
+  ],
+  "requested_at": 1520691155924
+}

--- a/spec/ribose/calendar_spec.rb
+++ b/spec/ribose/calendar_spec.rb
@@ -13,15 +13,15 @@ RSpec.describe Ribose::Calendar do
   end
 
   describe ".fetch" do
-    it "retrieves the details for a calendar" do
-      calendar_id = 123_456_789
+    it "retrieves the events for calendars" do
+      calendar_ids = [123, 456]
 
-      stub_ribose_calendar_fetch_api(calendar_id)
-      calendar = Ribose::Calendar.fetch(calendar_id)
+      stub_ribose_calendar_events_api(calendar_ids)
+      events = Ribose::Calendar.fetch(calendar_ids).events
 
-      expect(calendar.id).not_to be_nil
-      expect(calendar.owner_type).to eq("User")
-      expect(calendar.name).to eq("Sample 101")
+      expect(events.first.id).not_to be_nil
+      expect(events.first.calendar_id).to eq(123)
+      expect(events.first.name).to eq("Sample event")
     end
   end
 

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -98,6 +98,20 @@ module Ribose
       )
     end
 
+    def stub_ribose_calendar_events_api(calendar_ids, length: 7)
+      data = OpenStruct.new(
+        length: length,
+        cals: Ribose.encode_ids(calendar_ids),
+        start: Date.today.to_time.to_i / (60 * 60 * 24),
+      )
+
+      params = "cal_ids=#{data.cals}&length=#{data.length}&start=#{data.start}"
+
+      stub_api_response(
+        :get, "calendar/calendar/?#{params}", filename: "calendar_events"
+      )
+    end
+
     def stub_ribose_calendar_create_api(attributes)
       stub_api_response(
         :post,


### PR DESCRIPTION
This commit adds the support to retrieve the list of calendars events, and this endpoint also support multiple ids at the same time. In the underneath it usages the `id_pack` gem and prepare calendar ids, and it also usages the current data as `start` & default length of 7 days. Usages:

```ruby
Ribose::Calendar.fetch(calendar_ids, length: 7, start: Date.today)
```

Fixes: #97