### PR TITLE
Additional options support to calendar

### DIFF
--- a/lib/ribose/calendar.rb
+++ b/lib/ribose/calendar.rb
@@ -14,14 +14,14 @@ module Ribose
     # @params length [Integer] How many days to fetch
     # @return [Sawyer::Resource] The calendar events
     #
-    def self.fetch(calendar_ids, start: Date.today, length: 7)
+    def self.fetch(calendar_ids, start: Date.today, length: 7, **others)
       query = {
         length: length,
         cal_ids: Ribose.encode_ids(calendar_ids),
         start: start.to_time.to_i / (60 * 60 * 24),
       }
 
-      super(nil, query: query)
+      super(nil, query: others.merge(query))
     end
 
     private


### PR DESCRIPTION
In the calendar events interface, we specified the options and also sets some defaults for those, but it does not allow us to set any additional attributes. This commit adds an additional option support that will allow us pass anything we need.