### PR TITLE
Add interface to list calendar events

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,14 @@ Ribose::Calendar.create(
 Ribose::Calendar.delete(calendar_id)
 ```
 
+### Event
+
+#### List calendar events
+
+```ruby
+Ribose::Event.all(calendar_id)
+```
+
 ### User
 
 #### Create a signup request

--- a/lib/ribose.rb
+++ b/lib/ribose.rb
@@ -28,6 +28,7 @@ require "ribose/session"
 require "ribose/profile"
 require "ribose/wiki"
 require "ribose/member_role"
+require "ribose/event"
 
 module Ribose
   def self.root

--- a/lib/ribose/event.rb
+++ b/lib/ribose/event.rb
@@ -1,0 +1,13 @@
+module Ribose
+  class Event < Ribose::Base
+    # List calendar events
+    #
+    # @params calendar_id [Integer] Calendar Ids
+    # @params options [Hash] The options parameters
+    # @return [Sawyer::Resource] Calendar Events
+    #
+    def self.all(calendar_id, options = {})
+      Ribose::Calendar.fetch(calendar_id, options)
+    end
+  end
+end

--- a/spec/ribose/event_spec.rb
+++ b/spec/ribose/event_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+RSpec.describe Ribose::Event do
+  describe ".all" do
+    it "retrieves the list of events" do
+      calendar_id = 123
+      stub_ribose_calendar_events_api(calendar_id)
+
+      calendar_events = Ribose::Event.all(calendar_id).events
+
+      expect(calendar_events.first.id).not_to be_nil
+      expect(calendar_events.first.calendar_id).to eq(123)
+      expect(calendar_events.first.name).to eq("Sample event")
+    end
+  end
+end


### PR DESCRIPTION
This commit adds the interface to retrieve the list of calendar events for any of the specific calendar. In the underneath, it delegate the listing behavior to `Ribose::Calendar`, so it will actually allow to retrieve events for multiple calendars at a same time. Usages:

```ruby
Ribose::Event.all(calendar_id, option_hash)
```