### PR TITLE
Add interface to retrieve an event

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,6 +564,12 @@ Ribose::Calendar.delete(calendar_id)
 Ribose::Event.all(calendar_id)
 ```
 
+#### Fetch a calendar event
+
+```ruby
+Ribose::Event.fetch(calendar_id, event_id)
+```
+
 ### User
 
 #### Create a signup request

--- a/lib/ribose/event.rb
+++ b/lib/ribose/event.rb
@@ -1,5 +1,7 @@
 module Ribose
   class Event < Ribose::Base
+    include Ribose::Actions::Fetch
+
     # List calendar events
     #
     # @params calendar_id [Integer] Calendar Ids
@@ -8,6 +10,32 @@ module Ribose
     #
     def self.all(calendar_id, options = {})
       Ribose::Calendar.fetch(calendar_id, options)
+    end
+
+    # Fetch a calendar event
+    #
+    # @params calendar_id - The calendar ID
+    # @params event_id - The calendar event ID
+    # @return [Sawyer::Resource] Event details
+    #
+    def self.fetch(calendar_id, event_id, options = {})
+      new(options.merge(calendar_id: calendar_id, resource_id: event_id)).fetch
+    end
+
+    private
+
+    attr_reader :calendar_id
+
+    def resource
+      "event"
+    end
+
+    def extract_local_attributes
+      @calendar_id = attributes.delete(:calendar_id)
+    end
+
+    def resources_path
+      "calendar/calendar/#{calendar_id}/event"
     end
   end
 end

--- a/spec/fixtures/calendar_event.json
+++ b/spec/fixtures/calendar_event.json
@@ -1,0 +1,48 @@
+{
+  "filter": {
+    "enabled": [
+      123456789
+    ],
+    "userSetting": [0]
+  },
+  "cal_info": [
+    {
+      "id": 123456789,
+      "owner_type": "User",
+      "name": "johndoe",
+      "owner_id": "2970d105-5ccc-4a8c",
+      "owner_name": "Personal",
+      "display_name": "johndoe (Personal)",
+      "can_manage": true,
+      "can_create_event": true
+    }
+  ],
+  "spaces_permission": {
+    "268b0407-c3a3-4aad-8693-fdba789f7f0d": false,
+    "457e8438-1c6f-423f-8bf2-77b9d5102fb0": true,
+    "52e47e18-9a9d-4663-94c5-abcb18fa783a": true,
+    "a45387e2-a573-48ba-8df0-f1424d8a8ec9": false,
+    "a7f7b94e-a007-4457-868f-5af319706ad5": false
+  },
+  "event": {
+    "id": 456789,
+    "name": "Sample event",
+    "description": "",
+    "where": "",
+    "all_day": true,
+    "recurring_type": "not_repeat",
+    "my_note": null,
+    "old_head_id": null,
+    "calendar_id": 123456789,
+    "created_by": "2970d105-5ccc-4a8c-b0c4-ec32d539a00a",
+    "utc_start": "2018-03-13T12:00:00.000Z",
+    "utc_finish": "2018-03-13T13:00:00.000Z",
+    "utc_old_start": null,
+    "utc_old_finish": null,
+    "can_save": true,
+    "can_delete": true,
+    "timestamp": 1520690119
+  },
+  "head_event": null,
+  "recurring": []
+}

--- a/spec/ribose/event_spec.rb
+++ b/spec/ribose/event_spec.rb
@@ -13,4 +13,18 @@ RSpec.describe Ribose::Event do
       expect(calendar_events.first.name).to eq("Sample event")
     end
   end
+
+  describe ".fetch" do
+    it "retrives the details for an event" do
+      event_id = 456_789
+      calendar_id = 123_456_789
+
+      stub_ribose_event_fetch_api(calendar_id, event_id)
+      event = Ribose::Event.fetch(calendar_id, event_id)
+
+      expect(event.id).to eq(event_id)
+      expect(event.name).to eq("Sample event")
+      expect(event.calendar_id).to eq(calendar_id)
+    end
+  end
 end

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -127,6 +127,14 @@ module Ribose
       )
     end
 
+    def stub_ribose_event_fetch_api(calender_id, event_id)
+      stub_api_response(
+        :get,
+        "calendar/calendar/#{calender_id}/event/#{event_id}",
+        filename: "calendar_event",
+      )
+    end
+
     def stub_ribose_app_user_create_api(attributes)
       stub_api_response(
         :post,


### PR DESCRIPTION
This commit adds the interface to retrieve the details for any specific calendar events, and it also has additional support for options, that we can use to provide additional details

```ruby
Ribose::Event.fetch(calendar_id, event_id)
```