### PR TITLE
Interface to delete a calendar event

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,6 +570,12 @@ Ribose::Event.all(calendar_id)
 Ribose::Event.fetch(calendar_id, event_id)
 ```
 
+#### Delete a calendar event
+
+```ruby
+Ribose::Event.delete(calendar_id, event_id)
+```
+
 ### User
 
 #### Create a signup request

--- a/lib/ribose/event.rb
+++ b/lib/ribose/event.rb
@@ -1,6 +1,7 @@
 module Ribose
   class Event < Ribose::Base
     include Ribose::Actions::Fetch
+    include Ribose::Actions::Delete
 
     # List calendar events
     #
@@ -20,6 +21,16 @@ module Ribose
     #
     def self.fetch(calendar_id, event_id, options = {})
       new(options.merge(calendar_id: calendar_id, resource_id: event_id)).fetch
+    end
+
+    # Delete a calendar event
+    #
+    # @params calendar_id The calendar Id
+    # @params event_id  The calendar event Id
+    # @params options [Hash] The query params
+    #
+    def self.delete(calendar_id, event_id, options = {})
+      new(options.merge(calendar_id: calendar_id, resource_id: event_id)).delete
     end
 
     private

--- a/spec/ribose/event_spec.rb
+++ b/spec/ribose/event_spec.rb
@@ -27,4 +27,16 @@ RSpec.describe Ribose::Event do
       expect(event.calendar_id).to eq(calendar_id)
     end
   end
+
+  describe ".delete" do
+    it "removes a calendar event" do
+      event_id = 456_789
+      calendar_id = 123_456_789
+      stub_ribose_event_delete_api(calendar_id, event_id)
+
+      expect do
+        Ribose::Event.delete(calendar_id, event_id)
+      end.not_to raise_error
+    end
+  end
 end

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -135,6 +135,14 @@ module Ribose
       )
     end
 
+    def stub_ribose_event_delete_api(calender_id, event_id)
+      stub_api_response(
+        :delete,
+        "calendar/calendar/#{calender_id}/event/#{event_id}",
+        filename: "empty",
+      )
+    end
+
     def stub_ribose_app_user_create_api(attributes)
       stub_api_response(
         :post,


### PR DESCRIPTION
This commit adds the interface to delete a calendar event, on the successful request it will return an empty body with `200` status.

```ruby
Ribose::Event.delete(calendar_id, event_id)
```