### PR TITLE
Add interface to create a new event

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,6 +570,25 @@ Ribose::Event.all(calendar_id)
 Ribose::Event.fetch(calendar_id, event_id)
 ```
 
+#### Create a calendar event
+
+```ruby
+Ribose::Event.create(
+  calendar_id,
+  name: "Sample Event",
+  date_start: "04/04/2018",
+  time_start: "4:30pm",
+  date_finish: "04/04/2018",
+  time_finish: "5:30pm",
+  recurring_type: "not_repeat",
+  until: "never",
+  repeat_every: "1",
+  where: "Skype",
+  description: "Sample event",
+  all_day: false,
+)
+```
+
 #### Delete a calendar event
 
 ```ruby

--- a/lib/ribose/event.rb
+++ b/lib/ribose/event.rb
@@ -1,6 +1,7 @@
 module Ribose
   class Event < Ribose::Base
     include Ribose::Actions::Fetch
+    include Ribose::Actions::Create
     include Ribose::Actions::Delete
 
     # List calendar events
@@ -23,6 +24,23 @@ module Ribose
       new(options.merge(calendar_id: calendar_id, resource_id: event_id)).fetch
     end
 
+    # The resource key comes as plural, so this
+    # will override our existing create interface
+    #
+    def create
+      create_resource["events"]
+    end
+
+    # Create a calendar event
+    #
+    # @params calendar_id - The calendar Id
+    # @attributes [Hash] - New Event attributes
+    # @return [Sawyer::Resource] The new event
+    #
+    def self.create(calendar_id, attributes, options = {})
+      new(options.merge(calendar_id: calendar_id, **attributes)).create
+    end
+
     # Delete a calendar event
     #
     # @params calendar_id The calendar Id
@@ -39,6 +57,15 @@ module Ribose
 
     def resource
       "event"
+    end
+
+    def validate(date_start:, date_finish:, time_start:, time_finish:, **others)
+      others.merge(
+        date_start: date_start,
+        time_start: time_start,
+        date_finish: date_finish,
+        time_finish: time_finish,
+      )
     end
 
     def extract_local_attributes

--- a/spec/fixtures/event_created.json
+++ b/spec/fixtures/event_created.json
@@ -1,0 +1,21 @@
+{
+  "events": {
+    "id": 789012345,
+    "name": "Sample Event",
+    "description": "Sample event",
+    "where": "Skype",
+    "all_day": false,
+    "recurring_type": "not_repeat",
+    "my_note": null,
+    "old_head_id": null,
+    "calendar_id": 18987,
+    "created_by": "2970d105-5ccc",
+    "utc_start": "2018-04-04T18:00:00.000Z",
+    "utc_finish": "2018-04-04T18:30:00.000Z",
+    "utc_old_start": null,
+    "utc_old_finish": null,
+    "can_save": true,
+    "can_delete": true,
+    "timestamp": 1521387260
+  }
+}

--- a/spec/ribose/event_spec.rb
+++ b/spec/ribose/event_spec.rb
@@ -28,6 +28,19 @@ RSpec.describe Ribose::Event do
     end
   end
 
+  describe ".create" do
+    it "creates a new event" do
+      calendar_id = 123_456_789
+
+      stub_ribose_event_create_api(calendar_id, event_attributes)
+      event = Ribose::Event.create(calendar_id, event_attributes)
+
+      expect(event.id).not_to be_nil
+      expect(event.name).to eq(event_attributes[:name])
+      expect(event.description).to eq(event_attributes[:description])
+    end
+  end
+
   describe ".delete" do
     it "removes a calendar event" do
       event_id = 456_789
@@ -38,5 +51,22 @@ RSpec.describe Ribose::Event do
         Ribose::Event.delete(calendar_id, event_id)
       end.not_to raise_error
     end
+  end
+
+  def event_attributes
+    @event_attributes ||= {
+      name: "Sample Event",
+      recurring_type: "not_repeat",
+      until: "never",
+      repeat_every: "1",
+      where: "Skype",
+      description: "Sample event",
+      all_day: false,
+
+      date_start: "04/04/2018",
+      time_start: "4:30pm",
+      date_finish: "04/04/2018",
+      time_finish: "5:30pm",
+    }
   end
 end

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -135,6 +135,15 @@ module Ribose
       )
     end
 
+    def stub_ribose_event_create_api(calender_id, event_attributes)
+      stub_api_response(
+        :post,
+        "calendar/calendar/#{calender_id}/event",
+        data: { event: event_attributes },
+        filename: "event_created",
+      )
+    end
+
     def stub_ribose_event_delete_api(calender_id, event_id)
       stub_api_response(
         :delete,


### PR DESCRIPTION
This commit adds the interface to create a new calendar event, this expects us to provide the `calendar_id`, and the attributes for the event, it will take care of the rest. Usages:

```ruby
Ribose::Event.create(
  calendar_id,
  name: "Sample Event",
  date_start: "04/04/2018",
  time_start: "4:30pm",
  date_finish: "04/04/2018",
  time_finish: "5:30pm",
  recurring_type: "not_repeat",
  until: "never",
  repeat_every: "1",
  where: "Skype",
  description: "Sample event",
  all_day: false,
)
```