### PR TITLE
Interface to update calendar event

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,6 +589,14 @@ Ribose::Event.create(
 )
 ```
 
+#### Update a calendar event
+
+```ruby
+Ribose::Event.update(
+  calendar_id, event_id, new_attributes_hash, options_params
+)
+```
+
 #### Delete a calendar event
 
 ```ruby

--- a/lib/ribose/actions/create.rb
+++ b/lib/ribose/actions/create.rb
@@ -6,7 +6,8 @@ module Ribose
       extend Ribose::Actions::Base
 
       def create
-        create_resource[resource]
+        response = create_resource
+        response[resource] || response
       end
 
       private

--- a/lib/ribose/actions/update.rb
+++ b/lib/ribose/actions/update.rb
@@ -9,7 +9,8 @@ module Ribose
       #
       # @return [Sawyer::Resource] Update resource response
       def update
-        update_resource[resource]
+        response = update_resource
+        response[resource] || response
       end
 
       private

--- a/lib/ribose/event.rb
+++ b/lib/ribose/event.rb
@@ -2,6 +2,7 @@ module Ribose
   class Event < Ribose::Base
     include Ribose::Actions::Fetch
     include Ribose::Actions::Create
+    include Ribose::Actions::Update
     include Ribose::Actions::Delete
 
     # List calendar events
@@ -24,21 +25,27 @@ module Ribose
       new(options.merge(calendar_id: calendar_id, resource_id: event_id)).fetch
     end
 
-    # The resource key comes as plural, so this
-    # will override our existing create interface
-    #
-    def create
-      create_resource["events"]
-    end
-
     # Create a calendar event
     #
     # @params calendar_id - The calendar Id
     # @attributes [Hash] - New Event attributes
     # @return [Sawyer::Resource] The new event
     #
-    def self.create(calendar_id, attributes, options = {})
-      new(options.merge(calendar_id: calendar_id, **attributes)).create
+    def self.create(calendar_id, attrs, options = {})
+      new(options.merge(calendar_id: calendar_id, **attrs)).create["events"]
+    end
+
+    # Update a calendar event
+    #
+    # @params calendar_id [Integer] The calendar Id
+    # @params event_id [Integer] The calendar event Id
+    # @params attributes [Hash] New attributes for event
+    # @params options [Hash] The additional query params
+    #
+    def self.update(calendar_id, event_id, attributes, options = {})
+      new(options.merge(
+        calendar_id: calendar_id, resource_id: event_id, **attributes,
+      )).update["events"]
     end
 
     # Delete a calendar event

--- a/spec/fixtures/event_updated.json
+++ b/spec/fixtures/event_updated.json
@@ -1,0 +1,23 @@
+{
+  "events": [
+    {
+      "id": 345678901,
+      "name": "Sample event",
+      "description": "",
+      "where": "",
+      "all_day": true,
+      "recurring_type": "not_repeat",
+      "my_note": "",
+      "old_head_id": null,
+      "calendar_id": 123456789,
+      "created_by": "bdc6aced-f7d0-465d-9d8b",
+      "utc_start": "2017-11-07T12:00:00.000Z",
+      "utc_finish": "2017-11-07T13:00:00.000Z",
+      "utc_old_start": null,
+      "utc_old_finish": null,
+      "can_save": true,
+      "can_delete": true,
+      "timestamp": 1508401619
+    }
+  ]
+}

--- a/spec/ribose/event_spec.rb
+++ b/spec/ribose/event_spec.rb
@@ -41,6 +41,19 @@ RSpec.describe Ribose::Event do
     end
   end
 
+  describe ".update" do
+    it "updates an existing event" do
+      event_id = 345_678_901
+      calendar_id = 123_456_789
+
+      stub_ribose_event_update_api(calendar_id, event_id, event_attributes)
+      event = Ribose::Event.update(calendar_id, event_id, event_attributes)
+
+      expect(event.first.id).not_to be_nil
+      expect(event.first.name).to eq("Sample event")
+    end
+  end
+
   describe ".delete" do
     it "removes a calendar event" do
       event_id = 456_789

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -144,6 +144,15 @@ module Ribose
       )
     end
 
+    def stub_ribose_event_update_api(calender_id, event_id, attributes)
+      stub_api_response(
+        :put,
+        "calendar/calendar/#{calender_id}/event/#{event_id}",
+        data: { event: attributes },
+        filename: "event_updated",
+      )
+    end
+
     def stub_ribose_event_delete_api(calender_id, event_id)
       stub_api_response(
         :delete,


### PR DESCRIPTION
This commit adds the interface, that will allow user to update an existing event, and this also explicitly sets the options key so we return the properly parsed response to user.

```ruby
Ribose::Event.update(
  calendar_id, event_id, new_attributes_hash, options_params
)
```