### PR TITLE
Add interface to favorite a conversation

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,12 @@ Ribose::Conversation.update(space_id, conversation_id, new_attributes_hash)
 Ribose::Conversation.destroy(space_id: "space_id", conversation_id: "12345")
 ```
 
+#### Mark a conversation as favorite
+
+```ruby
+Ribose::Conversation.mark_as_favorite(space_id, conversation_id)
+```
+
 ### Message
 
 #### List Conversation Messages

--- a/lib/ribose/conversation.rb
+++ b/lib/ribose/conversation.rb
@@ -62,6 +62,24 @@ module Ribose
       new(space_id: space_id, conversation_id: conversation_id, **opts).delete
     end
 
+    def mark_as_favorite
+      response = Ribose::Request.put(
+        "#{resource_path}/mark_as_favorite",
+        resource_key.to_sym => { is_favorite: true },
+      )
+
+      response[resource]
+    end
+
+    # Mark a conversation a favorite
+    #
+    # @param space_id [String] The Space UUID
+    # @param conversation_id [String] Conversation UUID
+    #
+    def self.mark_as_favorite(space_id, conversation_id)
+      new(space_id: space_id, conversation_id: conversation_id).mark_as_favorite
+    end
+
     private
 
     attr_reader :space_id, :conversation_id

--- a/spec/fixtures/conversation.json
+++ b/spec/fixtures/conversation.json
@@ -7,7 +7,7 @@
     "name": "Trips to the Mars!",
     "tag_list": [],
     "published": false,
-    "is_favorite": false,
+    "is_favorite": true,
     "is_read": true,
     "allow_publish": false,
     "number_of_messages": 1,

--- a/spec/ribose/conversation_spec.rb
+++ b/spec/ribose/conversation_spec.rb
@@ -59,6 +59,20 @@ RSpec.describe Ribose::Conversation do
     end
   end
 
+  describe ".mark_as_favorite" do
+    it "marks a conversation as favorite" do
+      space_id = 123_456_789
+      conversation_id = 456_789
+      stub_ribose_space_conversation_mafav_api(space_id, conversation_id)
+
+      conversation = Ribose::Conversation.mark_as_favorite(
+        space_id, conversation_id
+      )
+
+      expect(conversation.is_favorite).to eq(true)
+    end
+  end
+
   describe ".destroy" do
     it "remvoes a conversation from a space" do
       space_id = 123456789

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -241,6 +241,14 @@ module Ribose
       )
     end
 
+    def stub_ribose_space_conversation_mafav_api(sid, cid)
+      stub_api_response(
+        :put,
+        [conversations_path(sid), cid, "mark_as_favorite"].join("/"),
+        filename: "conversation",
+      )
+    end
+
     def stub_ribose_space_conversation_remove(space_id, conversation_id)
       path = [conversations_path(space_id), conversation_id].join("/")
       stub_api_response(:delete, path, filename: "empty", status: 200)


### PR DESCRIPTION
This commit adds the interface, so user can favorite any of the existing conversation as favorite, the usages is pretty simple all we need to pass the `space_id` and `converstion_id` to it.

```ruby
Ribose::Conversation.mark_as_favorite(space_id, conversation_id)
```