### PR TITLE
Interface to list space categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -663,6 +663,14 @@ Ribose::Wiki.update(
 Ribose::Wiki.delete(space_id, wiki_id)
 ```
 
+### Space categories
+
+#### List space categories
+
+```ruby
+Ribose::SpaceCategory.all
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/ribose.rb
+++ b/lib/ribose.rb
@@ -29,6 +29,7 @@ require "ribose/profile"
 require "ribose/wiki"
 require "ribose/member_role"
 require "ribose/event"
+require "ribose/space_category"
 
 module Ribose
   def self.root

--- a/lib/ribose/space_category.rb
+++ b/lib/ribose/space_category.rb
@@ -1,0 +1,15 @@
+module Ribose
+  class SpaceCategory < Ribose::Base
+    include Ribose::Actions::All
+
+    private
+
+    def resources
+      nil
+    end
+
+    def resources_path
+      "space_categories"
+    end
+  end
+end

--- a/spec/fixtures/space_categories.json
+++ b/spec/fixtures/space_categories.json
@@ -1,0 +1,150 @@
+[
+  {
+    "id": 1,
+    "name": "animals"
+  },
+  {
+    "id": 2,
+    "name": "architecture"
+  },
+  {
+    "id": 3,
+    "name": "art"
+  },
+  {
+    "id": 4,
+    "name": "business"
+  },
+  {
+    "id": 5,
+    "name": "cars_and_motorcycles"
+  },
+  {
+    "id": 6,
+    "name": "common_interest"
+  },
+  {
+    "id": 7,
+    "name": "diy_and_crafts"
+  },
+  {
+    "id": 8,
+    "name": "design"
+  },
+  {
+    "id": 9,
+    "name": "education"
+  },
+  {
+    "id": 10,
+    "name": "entertainment"
+  },
+  {
+    "id": 11,
+    "name": "fashion"
+  },
+  {
+    "id": 12,
+    "name": "film_music_books"
+  },
+  {
+    "id": 13,
+    "name": "food_and_drink"
+  },
+  {
+    "id": 14,
+    "name": "gardening"
+  },
+  {
+    "id": 15,
+    "name": "geek"
+  },
+  {
+    "id": 16,
+    "name": "geography"
+  },
+  {
+    "id": 17,
+    "name": "groups_and_organizations"
+  },
+  {
+    "id": 18,
+    "name": "hair_and_beauty"
+  },
+  {
+    "id": 19,
+    "name": "health_and_fitness"
+  },
+  {
+    "id": 20,
+    "name": "history"
+  },
+  {
+    "id": 21,
+    "name": "holidays_and_events"
+  },
+  {
+    "id": 22,
+    "name": "home_decor"
+  },
+  {
+    "id": 23,
+    "name": "humor"
+  },
+  {
+    "id": 24,
+    "name": "illustrations_and_posters"
+  },
+  {
+    "id": 25,
+    "name": "kids"
+  },
+  {
+    "id": 26,
+    "name": "mens_fashion"
+  },
+  {
+    "id": 27,
+    "name": "outdoors"
+  },
+  {
+    "id": 28,
+    "name": "philosophy"
+  },
+  {
+    "id": 29,
+    "name": "photography"
+  },
+  {
+    "id": 30,
+    "name": "products"
+  },
+  {
+    "id": 31,
+    "name": "religion_and_spirituality"
+  },
+  {
+    "id": 32,
+    "name": "science_and_nature"
+  },
+  {
+    "id": 33,
+    "name": "sports"
+  },
+  {
+    "id": 34,
+    "name": "technology"
+  },
+  {
+    "id": 35,
+    "name": "travel"
+  },
+  {
+    "id": 36,
+    "name": "weddings"
+  },
+  {
+    "id": 37,
+    "name": "others"
+  }
+]

--- a/spec/ribose/space_category_spec.rb
+++ b/spec/ribose/space_category_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+
+RSpec.describe Ribose::SpaceCategory do
+  describe ".all" do
+    it "retrieves the list of space categories" do
+      stub_ribose_space_categories_api
+      categories = Ribose::SpaceCategory.all
+
+      expect(categories.first.id).not_to be_nil
+      expect(categories.first.name).to eq("animals")
+    end
+  end
+end

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -475,6 +475,12 @@ module Ribose
       )
     end
 
+    def stub_ribose_space_categories_api
+      stub_api_response(
+        :get, "space_categories", filename: "space_categories"
+      )
+    end
+
     private
 
     def ribose_endpoint(endpoint)


### PR DESCRIPTION
This commit adds the interface to list all of the ribose space categories, and interface does not requires any parameters for that, Usages:

```ruby
Ribose::SpaceCategory.all
```