### PR TITLE
Add interface to fetch space file icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,12 @@ Ribose::SpaceFile.all(space_id, options)
 Ribose::SpaceFile.fetch(space_id, file_id, options = {})
 ```
 
+#### Fetch a file icon
+
+```ruby
+Ribose::SpaceFile.fetch_icon(space_id, file_id, options = {})
+```
+
 #### Create a file upload
 
 ```ruby

--- a/lib/ribose/space_file.rb
+++ b/lib/ribose/space_file.rb
@@ -66,6 +66,20 @@ module Ribose
       new(space_id: space_id, resource_id: file_id, **options).delete
     end
 
+    def fetch_icon
+      Ribose::Request.get([resource_path, "icon"].join("/"))
+    end
+
+    # Fetch a space file icon
+    #
+    # @param space_id [String] The Space UUID
+    # @param file_id [String] The space file ID
+    # @return [Sawyer::Resource]
+    #
+    def self.fetch_icon(space_id, file_id, options = {})
+      new(space_id: space_id, resource_id: file_id, **options).fetch_icon
+    end
+
     private
 
     attr_reader :space_id

--- a/spec/fixtures/space_file_icon.json
+++ b/spec/fixtures/space_file_icon.json
@@ -1,0 +1,4 @@
+{
+  "icon_processed": true,
+  "icon_path": "/spaces/files/icon_path?type=usual"
+}

--- a/spec/ribose/space_file_spec.rb
+++ b/spec/ribose/space_file_spec.rb
@@ -67,6 +67,19 @@ RSpec.describe Ribose::SpaceFile do
     end
   end
 
+  describe ".fetch_icon" do
+    it "retrives the details for a file icon" do
+      file_id = 456_789_012
+      space_id = 123_456_789
+
+      stub_ribose_space_file_fetch_icon_api(space_id, file_id)
+      icon = Ribose::SpaceFile.fetch_icon(space_id, file_id)
+
+      expect(icon.icon_processed).to be_truthy
+      expect(icon.icon_path).to eq("/spaces/files/icon_path?type=usual")
+    end
+  end
+
   def file_attributes
     {
       file: sample_fixture_file,

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -193,6 +193,11 @@ module Ribose
       stub_api_response(:get, file_endppoint, filename: "space_file")
     end
 
+    def stub_ribose_space_file_fetch_icon_api(space_id, file_id)
+      path = ["spaces", space_id, "file", "files", file_id, "icon"].join("/")
+      stub_api_response(:get, path, filename: "space_file_icon")
+    end
+
     def stub_ribose_space_file_update_api(space_id, file_id, attributes)
       stub_api_response(
         :put,


### PR DESCRIPTION
This commit adds the `fetch_icon` interface to the space file, so now we can use this one to retrieve the details for any of a space file icon. Usages:

```ruby
Ribose::SpaceFile.fetch_icon(space_id, file_id, options = {})
```