### PR TITLE
Add interface to fetch file version

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,16 @@ Ribose::SpaceFile.update(space_id, file_id, new_file_attributes = {})
 Ribose::SpaceFile.delete(space_id, file_id)
 ```
 
+### File Version
+
+#### Fetch file version
+
+```ruby
+Ribose::FileVersion.fetch(
+  space_id: space_id, file_id: file_id, version_id: version_id
+)
+```
+
 ### Conversations
 
 #### Listing Space Conversations

--- a/lib/ribose.rb
+++ b/lib/ribose.rb
@@ -30,6 +30,7 @@ require "ribose/wiki"
 require "ribose/member_role"
 require "ribose/event"
 require "ribose/space_category"
+require "ribose/file_version"
 
 module Ribose
   def self.root

--- a/lib/ribose/file_version.rb
+++ b/lib/ribose/file_version.rb
@@ -1,0 +1,42 @@
+module Ribose
+  class FileVersion < Ribose::Base
+    include Ribose::Actions::Fetch
+
+    # Fetch file version
+    #
+    # @params :space_id [UUID] The space Id
+    # @params :file_id [UUID] The space file Id
+    # @params :version_id [UUID] The file version Id
+    # @returns [Sawyer::Resource] The file version
+    #
+    def self.fetch(space_id:, file_id:, version_id:, **options)
+      new(
+        file_id: file_id,
+        space_id: space_id,
+        resource_id: version_id,
+        **options,
+      ).fetch
+    end
+
+    private
+
+    attr_reader :file_id, :space_id
+
+    def resource
+      nil
+    end
+
+    def extract_local_attributes
+      @file_id = attributes.delete(:file_id)
+      @space_id = attributes.delete(:space_id)
+    end
+
+    def resource_path
+      [files_path, file_id, "versions", resource_id].join("/")
+    end
+
+    def files_path
+      ["spaces", space_id, "file", "files"].join("/")
+    end
+  end
+end

--- a/spec/fixtures/file_version.json
+++ b/spec/fixtures/file_version.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "name": "sample.png",
+  "description": "",
+  "created_at": "2017-11-30T09:12:03.000+00:00",
+  "updated_at": "2017-11-30T09:12:05.000+00:00",
+  "position": 1,
+  "current_version_id": 789012,
+  "icon_path": "/spaces/456789/file/files/11570/versions/13235?type=usual",
+  "content_size": 81421,
+  "author": "John Doe",
+  "content_type": "image/png",
+  "file_info_id": 11570
+}

--- a/spec/ribose/file_version_spec.rb
+++ b/spec/ribose/file_version_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+
+RSpec.describe Ribose::FileVersion do
+  describe ".fetch" do
+    it "retrieves the details of a file version" do
+      file_id = 123_456
+      space_id = 456_789
+      version_id = 789_012
+
+      stub_ribose_file_version_fetch_api(space_id, file_id, version_id)
+      file_version = Ribose::FileVersion.fetch(
+        space_id: space_id, file_id: file_id, version_id: version_id,
+      )
+
+      expect(file_version.version).to eq(1)
+      expect(file_version.author).to eq("John Doe")
+      expect(file_version.current_version_id).to eq(789012)
+    end
+  end
+end

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -212,6 +212,14 @@ module Ribose
       stub_api_response(:delete, file_endppoint, filename: "empty")
     end
 
+    def stub_ribose_file_version_fetch_api(sid, fid, vid)
+      stub_api_response(
+        :get,
+        ["spaces", sid, "file/files", fid, "versions", vid].join("/"),
+        filename: "file_version",
+      )
+    end
+
     def stub_ribose_space_conversation_list(space_id)
       stub_api_response(
         :get, conversations_path(space_id), filename: "conversations"


### PR DESCRIPTION
This commit adds the interface to fetch the file version, it expects us to provide the `space_id`, `file_id` and `version_id` then it will return the details fro that specific file version