### PR TITLE
Interface to create a new file version

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,18 @@ Ribose::FileVersion.fetch(
 )
 ```
 
+#### Create a new file version
+
+```ruby
+Ribose::FileVersion.create(
+  space_id: your_space_id,
+  file_id: existing_file_id_in_space,
+  file: file_path_for_the_new_version,
+
+  **any_other_additional_attributes
+)
+```
+
 ### Conversations
 
 #### Listing Space Conversations

--- a/lib/ribose/file_uploader.rb
+++ b/lib/ribose/file_uploader.rb
@@ -51,7 +51,9 @@ module Ribose
 
     def notify_ribose_file_upload_endpoint(response, key)
       if response.status.to_i == 200
-        content = Request.post(space_file_path, file_attributes.merge(key: key))
+        attributes = notifiable_attributes(file_attributes, key)
+
+        content = Request.post(space_file_path, attributes)
         content.is_a?(Sawyer::Resource) ? content : parse_to_ribose_os(content)
       end
     end
@@ -75,6 +77,10 @@ module Ribose
 
     def parse_to_ribose_os(content)
       JSON.parse(content, object_class: Ribose::OpenStruct)
+    end
+
+    def notifiable_attributes(attributes, key)
+      attributes.merge(key: key)
     end
 
     def file_attributes

--- a/lib/ribose/file_version.rb
+++ b/lib/ribose/file_version.rb
@@ -1,3 +1,5 @@
+require "ribose/version_uploader"
+
 module Ribose
   class FileVersion < Ribose::Base
     include Ribose::Actions::Fetch
@@ -16,6 +18,22 @@ module Ribose
         resource_id: version_id,
         **options,
       ).fetch
+    end
+
+    # Create a new file version
+    #
+    # @params space_id [UUID] The space UUID
+    # @params file_id [Integer] The space file ID
+    # @params file [File] The new version for file
+    # @params attributes [Hash] Other file attributes
+    # @return [Sawyer::Resource] Newly updated version
+    #
+    def self.create(space_id, file_id, file:, **attributes)
+      upload = VersionUploader.upload(
+        space_id, file_id, attributes.merge(file: file)
+      )
+
+      upload[:attachment]
     end
 
     private

--- a/lib/ribose/version_uploader.rb
+++ b/lib/ribose/version_uploader.rb
@@ -1,0 +1,27 @@
+require "ribose/file_uploader"
+
+module Ribose
+  class VersionUploader < Ribose::FileUploader
+    def initialize(space_id, file_id, file:, **attributes)
+      @file_id = file_id
+      super(space_id, file: file, **attributes)
+    end
+
+    def self.upload(space_id, file_id, file:, **attributes)
+      new(space_id, file_id, attributes.merge(file: file)).create
+    end
+
+    private
+
+    attr_reader :file_id
+
+    def notifiable_attributes(attributes, key)
+      attributes[:file_info_version] = attributes.delete(:file_info)
+      attributes.merge(key: key)
+    end
+
+    def space_file_path
+      ["spaces", space_id, "file", "files", file_id, "versions"].join("/")
+    end
+  end
+end

--- a/spec/ribose/file_version_spec.rb
+++ b/spec/ribose/file_version_spec.rb
@@ -17,4 +17,30 @@ RSpec.describe Ribose::FileVersion do
       expect(file_version.current_version_id).to eq(789012)
     end
   end
+
+  describe ".create" do
+    it "create a new file version" do
+      file_id = 123_456
+      space_id = 456_789
+
+      stub_ribose_space_file_upload_api(space_id, file_attributes, file_id)
+      file = Ribose::FileVersion.create(space_id, file_id, file_attributes)
+
+      expect(file.id).not_to be_nil
+      expect(file.author).to eq("John Doe")
+      expect(file.content_type).to eq("image/png")
+    end
+  end
+
+  def file_attributes
+    {
+      file: sample_fixture_file,
+      description: "Version 2.0",
+      tag_list: "tags for new version",
+    }
+  end
+
+  def sample_fixture_file
+    @sample_fixture_file ||= File.join(Ribose.root, "spec/fixtures/sample.png")
+  end
 end

--- a/spec/support/file_upload_stub.rb
+++ b/spec/support/file_upload_stub.rb
@@ -2,16 +2,16 @@ require "faraday"
 
 module Ribose
   module FileUploadStub
-    def stub_ribose_space_file_upload_api(space_id, attributes)
+    def stub_ribose_space_file_upload_api(space_id, attributes, file_id = nil)
       stub_ribose_aws_s3_file_upload_api
-      stub_ribose_file_prepare_api(space_id, attributes)
-      stub_ribose_file_upload_notify_api(space_id, attributes)
+      stub_ribose_file_prepare_api(space_id, attributes, file_id)
+      stub_ribose_file_upload_notify_api(space_id, attributes, file_id)
     end
 
-    def stub_ribose_file_prepare_api(space_id, attributes)
+    def stub_ribose_file_prepare_api(space_id, attributes, file_id = nil)
       stub_api_response(
         :get,
-        ribose_prepare_endpoint(space_id, attributes),
+        ribose_prepare_endpoint(space_id, attributes, file_id),
         filename: "file_upload_prepared",
       )
     end
@@ -22,11 +22,11 @@ module Ribose
         to_return(response_with(filename: "empty", status: 200))
     end
 
-    def stub_ribose_file_upload_notify_api(space_id, attributes)
+    def stub_ribose_file_upload_notify_api(space_id, attributes, file_id = nil)
       stub_api_response(
         :post,
-        ribose_file_endpoint(space_id),
-        data: build_notify_request_body(attributes),
+        ribose_file_endpoint(space_id, file_id),
+        data: build_notify_request_body(attributes, file_id),
         filename: "file_uploaded",
         content_type: "text/html",
       )
@@ -34,12 +34,14 @@ module Ribose
 
     private
 
-    def ribose_file_endpoint(space_id)
-      ["spaces", space_id, "file", "files"].join("/")
+    def ribose_file_endpoint(space_id, file_id = nil)
+      end_path = file_id ? "#{file_id}/versions" : nil
+      ["spaces", space_id, "file", "files", end_path].compact.join("/")
     end
 
-    def ribose_prepare_endpoint(sid, attrs)
-      [ribose_file_endpoint(sid), "prepare?#{prepare_params(attrs)}"].join("/")
+    def ribose_prepare_endpoint(sid, attrs, file_id = nil)
+      [ribose_file_endpoint(sid, file_id), "prepare?#{prepare_params(attrs)}"].
+        join("/")
     end
 
     def prepare_params(attributes)
@@ -50,9 +52,11 @@ module Ribose
       )
     end
 
-    def build_notify_request_body(attributes)
+    def build_notify_request_body(attributes, file_id = nil)
+      file_info_key = file_id ? "file_info_version" : "file_info"
+
       extract_file_details(attributes).merge(
-        file_info: extract_file_info(attributes),
+        file_info_key.to_sym => extract_file_info(attributes),
         key: "uploads/123456789/${filename}",
       )
     end


### PR DESCRIPTION
The Ribose API allows us to upload multiple versions for any of the existing files, and this interface enables that capability, so now we can easily upload a new version for an existing file.

```ruby
Ribose::FileVersion.create(
  space_id: your_space_id,
  file_id: existing_file_id_in_space,
  file: file_path_for_the_new_version,

  **any_other_additional_attributes
)
```