### PR TITLE
Fix file upload related error

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,9 +1,4 @@
 AllCops:
-  Include:
-    - "**/*.rake"
-    - "**/Gemfile"
-    - "**/Rakefile"
-
   Exclude:
     - db/schema.rb
 
@@ -357,8 +352,18 @@ Style/TrailingCommaInArguments:
     - no_comma
   Enabled: true
 
-Style/TrailingCommaInLiteral:
-  Description: 'Checks for trailing comma in array and hash literals.'
+Style/TrailingCommaInArrayLiteral:
+  Description: 'Checks for trailing comma in array literals.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
+  EnforcedStyleForMultiline: comma
+  SupportedStylesForMultiline:
+    - comma
+    - consistent_comma
+    - no_comma
+  Enabled: true
+
+Style/TrailingCommaInHashLiteral:
+  Description: 'Checks for trailing comma in hash literals.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
   EnforcedStyleForMultiline: comma
   SupportedStylesForMultiline:
@@ -401,6 +406,13 @@ Style/WordArray:
 Layout/AlignParameters:
   Description: 'Here we check if the parameters on a multi-line method call or definition are aligned.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-double-indent'
+  Enabled: false
+
+Layout/ConditionPosition:
+  Description: >-
+                 Checks for condition placed in a confusing position relative to
+                 the keyword.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#same-line-condition'
   Enabled: false
 
 Layout/DotPosition:
@@ -455,13 +467,6 @@ Lint/CircularArgumentReference:
   Description: "Don't refer to the keyword argument in the default value."
   Enabled: false
 
-Lint/ConditionPosition:
-  Description: >-
-                 Checks for condition placed in a confusing position relative to
-                 the keyword.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#same-line-condition'
-  Enabled: false
-
 Lint/DeprecatedClassMethods:
   Description: 'Check for deprecated class method calls.'
   Enabled: false
@@ -487,7 +492,7 @@ Lint/HandleExceptions:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions'
   Enabled: false
 
-Lint/LiteralInCondition:
+Lint/LiteralAsCondition:
   Description: 'Checks of literals used in conditions.'
   Enabled: false
 
@@ -528,7 +533,7 @@ Lint/UnderscorePrefixedVariableName:
   Description: 'Do not use prefix `_` for a variable that is used.'
   Enabled: false
 
-Lint/UnneededDisable:
+Lint/UnneededCopDisableDirective:
   Description: >-
                  Checks for rubocop:disable comments that can be removed.
                  Note: this cop is not disabled when disabling all cops.

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -531,11 +531,11 @@ module Ribose
       end
     end
 
-    def response_with(filename:, status:)
+    def response_with(filename:, status:, content_type: "application/json")
       {
         status: status,
         body: ribose_fixture(filename),
-        headers: { content_type: "application/json" },
+        headers: { content_type: content_type },
       }
     end
 
@@ -546,11 +546,15 @@ module Ribose
       File.read(File.expand_path(file_path, __FILE__))
     end
 
-    def stub_api_response(method, endpoint, filename:,
-                          status: 200, data: nil, client: nil)
+    def stub_api_response(method, endpoint, filename:, status: 200, data: nil,
+                          client: nil, content_type: "application/json")
       stub_request(method, ribose_endpoint(endpoint)).
         with(ribose_headers(data: data, client: client)).
-        to_return(response_with(filename: filename, status: status))
+        to_return(
+          response_with(
+            filename: filename, status: status, content_type: content_type,
+          ),
+        )
     end
   end
 end

--- a/spec/support/file_upload_stub.rb
+++ b/spec/support/file_upload_stub.rb
@@ -28,6 +28,7 @@ module Ribose
         ribose_file_endpoint(space_id),
         data: build_notify_request_body(attributes),
         filename: "file_uploaded",
+        content_type: "text/html",
       )
     end
 


### PR DESCRIPTION
On the file upload endpoint, the final `notify` returns the content header as `text/html` which causing an issue with the `Sawyer` gem, as it expects the response header to be `json` otherwise it won't parse.

This commit adds a temporary fix, that will bypass the gem and parse the response to open struct, so everything on the client side will work as usual.

Fixes #131