### PR TITLE
Fix unknown file upload related issues

### DIFF
--- a/lib/ribose/file_uploader.rb
+++ b/lib/ribose/file_uploader.rb
@@ -72,7 +72,8 @@ module Ribose
 
     def content_type_form_file
       require "mime/types"
-      MIME::Types.type_for(file.path).first.content_type
+      mime = MIME::Types.type_for(file.path).first
+      mime ? mime.content_type : "application/octet-stream"
     end
 
     def parse_to_ribose_os(content)

--- a/spec/ribose/file_uploader_spec.rb
+++ b/spec/ribose/file_uploader_spec.rb
@@ -14,11 +14,24 @@ RSpec.describe Ribose::FileUploader do
         expect(file_upload.attachment.content_type).to eq("image/png")
       end
     end
+
+    context "with unknown file type" do
+      it "creates a new upload as octet-stream" do
+        space_id = 123_456_789
+        attributes = file_attributes(File.join(Ribose.root, "Rakefile"))
+
+        stub_ribose_space_file_upload_api(space_id, attributes)
+        file_upload = Ribose::FileUploader.upload(space_id, attributes)
+
+        expect(file_upload.attachment.id).not_to be_nil
+        expect(file_upload.attachment.author).to eq("John Doe")
+      end
+    end
   end
 
-  def file_attributes
+  def file_attributes(file = nil)
     {
-      file: sample_fixture_file,
+      file: file || sample_fixture_file,
       tag_list: "sample, file, samplefile",
       description: "This is a sample file",
     }

--- a/spec/support/file_upload_stub.rb
+++ b/spec/support/file_upload_stub.rb
@@ -63,7 +63,8 @@ module Ribose
 
     def content_type_form_file(file)
       require "mime/types"
-      MIME::Types.type_for(file).first.content_type
+      mime = MIME::Types.type_for(file).first
+      mime ? mime.content_type : "application/octet-stream"
     end
 
     def extract_file_details(attributes)


### PR DESCRIPTION
Currently, the ribose gem is strictly looking for a file type so if there is no extension exists then it's throwing an error, which is not expected. The ribose app is also allowing user to upload an unknown type of file.

So, this commit changes the existing behavior and it should allow user to upload any type of file, and when it can't determine the file type then it will sent `application/octet-stream` as type

Fixes #130