### PR TITLE
Interface to disconnect a connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,16 @@ and it will return the connection as `Sawyer::Resource`.
 Ribose::Connection.all
 ```
 
+#### Disconnect a connection
+
+To disconnect with an existing connection, we can use `Connection.disconnect`
+interface as following. This expect us to provide the connection id, and it also
+support an additional options hash to provide custom options.
+
+```ruby
+Ribose::Connection.disconnect(connection_id, options)
+```
+
 #### Connection suggestions
 
 To retrieve the list of user connection suggestions,

--- a/lib/ribose/connection.rb
+++ b/lib/ribose/connection.rb
@@ -1,6 +1,7 @@
 module Ribose
   class Connection < Ribose::Base
     include Ribose::Actions::All
+    include Ribose::Actions::Delete
 
     # List Connections
     #
@@ -24,6 +25,20 @@ module Ribose
     def self.suggestions(client: nil, **options)
       Request.get("people_finding", client: client, query: options).
         suggested_connection
+    end
+
+    # Disconnect
+    #
+    # Disconnect connection / contact with the provided
+    # connection id. This will return nothing for successful
+    # request, but if disconnect fails then it will raise an
+    # Error for the client.
+    #
+    # @params resource_id [Integer] Connection Id
+    # @return nil
+    #
+    def self.disconnect(resource_id, options = {})
+      delete(resource_id, options)
     end
 
     private

--- a/spec/ribose/connection_spec.rb
+++ b/spec/ribose/connection_spec.rb
@@ -23,4 +23,15 @@ RSpec.describe Ribose::Connection do
       expect(suggestions.first.name).to eq("Jennie Doe")
     end
   end
+
+  describe ".disconnect" do
+    it "disconnect with provided connection" do
+      connection_id = 123_456
+      stub_ribose_connection_delete_api(connection_id)
+
+      expect do
+        Ribose::Connection.disconnect(connection_id)
+      end.not_to raise_error
+    end
+  end
 end

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -316,6 +316,12 @@ module Ribose
       stub_api_response(:get, "people/connections?s=", filename: "connections")
     end
 
+    def stub_ribose_connection_delete_api(id)
+      stub_api_response(
+        :delete, ["people", "connections", id].join("/"), filename: "empty"
+      )
+    end
+
     def stub_ribose_suggestion_list_api
       stub_api_response(
         :get, "people_finding", filename: "connection_suggestion"


### PR DESCRIPTION
This commit adds the interface to disconnect with an existing user connection. This interface expect us to provide a valid connection id, but it also allow an additional option hash to provide custom configuration options.

```ruby
Ribose::Connection.disconnect(connection_id, options)
```

Fixes #47