### PR TITLE
Add support to download a file version

### DIFF
--- a/lib/ribose/configuration.rb
+++ b/lib/ribose/configuration.rb
@@ -16,6 +16,7 @@ module Ribose
     def web_url
       ["https", api_host].join("://")
     end
+
     def add_default_middleware(builder)
       builder.use(Ribose::Response::RaiseError)
       builder.response(:logger, nil, bodies: true) if debug_mode?

--- a/lib/ribose/space_file.rb
+++ b/lib/ribose/space_file.rb
@@ -34,6 +34,21 @@ module Ribose
       new(space_id: space_id, resource_id: file_id, **options).fetch
     end
 
+    # Download a space file
+    #
+    # @param space_id [UUID] The Space UUID
+    # @param file_id [Integer] The File Id
+    # @param options [Hash] Options as key and value pair.
+    #
+    #   Two important keys are :version_id, and :output and
+    #   if these are provided then it will use those otherwise
+    #   it will do additional request to retirve those details
+    #
+    def self.download(space_id, file_id, options = {})
+      options[:version_id] ||= fetch(space_id, file_id).current_version_id
+      Ribose::FileVersion.download(space_id, file_id, **options)
+    end
+
     # Create a new file upload
     #
     # @param space_id [String] The Space UUID

--- a/spec/ribose/file_version_spec.rb
+++ b/spec/ribose/file_version_spec.rb
@@ -18,6 +18,29 @@ RSpec.describe Ribose::FileVersion do
     end
   end
 
+  describe ".download" do
+    context "with version id specified" do
+      it "downloads the specific file version" do
+        file_id = 123_456
+        space_id = 456_789
+        version_id = 789_012
+
+        output_file = "./tmp/download"
+        content = "This is the content in the file"
+
+        stub_aws_file_version_download_api(content)
+        buffer = stub_file_write_to_io(output_file)
+        stub_ribose_file_version_download_api(space_id, file_id, version_id)
+
+        Ribose::FileVersion.download(
+          space_id, file_id, version_id: version_id, output: output_file
+        )
+
+        expect(buffer).to eq(content)
+      end
+    end
+  end
+
   describe ".create" do
     it "create a new file version" do
       file_id = 123_456
@@ -42,5 +65,12 @@ RSpec.describe Ribose::FileVersion do
 
   def sample_fixture_file
     @sample_fixture_file ||= File.join(Ribose.root, "spec/fixtures/sample.png")
+  end
+
+  def stub_file_write_to_io(output_file)
+    buffer = StringIO.new
+    allow(File).to receive(:open).with(output_file, "w").and_yield(buffer)
+
+    buffer.string
   end
 end

--- a/spec/ribose/space_file_spec.rb
+++ b/spec/ribose/space_file_spec.rb
@@ -28,6 +28,37 @@ RSpec.describe Ribose::SpaceFile do
     end
   end
 
+  describe ".download" do
+    context "without specific version id" do
+      it "fetch version id and then downloads the file" do
+        file_id = 123_456_789
+        space_id = 456_789_012
+
+        allow(Ribose::FileVersion).to receive(:download)
+        stub_ribose_space_file_fetch_api(space_id, file_id)
+
+        Ribose::SpaceFile.download(space_id, file_id)
+
+        expect(Ribose::FileVersion).to have_received(:download).
+          with(space_id, file_id, version_id: 11559)
+      end
+    end
+
+    context "with specific version id" do
+      it "sends downlod message to the downloader" do
+        file_id = 123_456_789
+        space_id = 456_789_012
+        version_id = 123_456_789
+
+        allow(Ribose::FileVersion).to receive(:download)
+        Ribose::SpaceFile.download(space_id, file_id, version_id: version_id)
+
+        expect(Ribose::FileVersion).to have_received(:download).
+          with(space_id, file_id, version_id: version_id)
+      end
+    end
+  end
+
   describe ".create" do
     it "creates a new file with provided details" do
       space_id = 123_456_789

--- a/spec/support/fake_ribose_api.rb
+++ b/spec/support/fake_ribose_api.rb
@@ -226,6 +226,17 @@ module Ribose
       )
     end
 
+    def stub_ribose_file_version_download_api(sid, fid, vid)
+      version = ["spaces", sid, "file/files", fid, "versions", vid].join("/")
+      stub_request(:get, ribose_endpoint(version)).to_return(
+        headers: { location: "https://ribose-data.aws.com", status: 302 },
+      )
+    end
+
+    def stub_aws_file_version_download_api(content)
+      stub_request(:get, "https://ribose-data.aws.com").to_return(body: content)
+    end
+
     def stub_ribose_space_conversation_list(space_id)
       stub_api_response(
         :get, conversations_path(space_id), filename: "conversations"


### PR DESCRIPTION
This commit adds an interface, that will allow a user to download any file version from a user space. The required arguments for this interface are `space_id` and `file_id`, and if nothing else is provided then it will do additional API request to fetch the remaining details. Usages:

```ruby
Ribose::SpaceFile.download(
  space_id, file_id, version_id: 1, output: "output_file", **options,
)
```

Fixes #129 