### PR TITLE
Clarify API host related instructions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -41,8 +41,9 @@ Ribose.configure do |config|
   config.user_password = "your-password"
 
   # INFRA_ID is a 7-digit id, which can be found from the network requests
-  # e.g. ed6af7b for current production environment
-  config.api_host      = URI.parse('https://app-INFRA_ID.ribose.com')
+  # e.g. ed6af7b for current production environment.
+  # Note: add the host without the protocols eq: http, https
+  config.api_host      = "app-INFRA_ID.ribose.com"
 
   # There are also some default configurations. Normally you do not need to
   # change those unless you have some very specific use cases.
@@ -60,7 +61,7 @@ Or:
 
 [source,ruby]
 ----
-Ribose.configuration.api_host = "https://app-INFRA_ID.ribose.com"
+Ribose.configuration.api_host = "app-INFRA_ID.ribose.com"
 Ribose.configuration.user_email = "your-email@example.com"
 Ribose.configuration.user_password = "your-password"
 ```

--- a/ribose.gemspec
+++ b/ribose.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.files         = `git ls-files`.split("\n")
   spec.test_files    = `git ls-files -- {spec}/*`.split("\n")
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.1.9")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
 
   spec.add_dependency "id_pack", "~> 1.0.1"
   spec.add_dependency "mime-types", "~> 3.1"


### PR DESCRIPTION
The API host related instruction was not that much clear, so it could easily trick the user what kind of host we are expecting.
This commit changes that and try to make it bit clear.